### PR TITLE
108

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -2,7 +2,7 @@
 # SPDX-License-Identifier: MIT
 ---
 # yamllint disable rule:line-length
-name: tarpaulin
+name: coverage
 'on':
   push:
   pull_request:
@@ -12,17 +12,14 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v5
-      - name: Install OpenSSL 1.1
-        run: |
-          wget http://archive.ubuntu.com/ubuntu/pool/main/o/openssl/libssl1.1_1.1.1f-1ubuntu2_amd64.deb
-          sudo dpkg -i libssl1.1_1.1.1f-1ubuntu2_amd64.deb
       - uses: dtolnay/rust-toolchain@stable
         with:
           toolchain: stable
-      - uses: actions-rs/tarpaulin@v0.1
-        with:
-          version: '0.22.0'
-          args: '--all-features --exclude-files src/lib.rs -- --test-threads 1'
+      - name: Install cargo-llvm-cov
+        uses: taiki-e/install-action@cargo-llvm-cov
+      - name: Generate code coverage
+        run: cargo llvm-cov --all-features --workspace --lcov --output-path lcov.info -- --test-threads 1
       - uses: codecov/codecov-action@v5
         with:
+          files: lcov.info
           fail_ci_if_error: true

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -62,6 +62,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "anyhow"
+version = "1.0.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a23eb6b1614318a8071c9b2521f36b424b2c83db5eb3a0fead4a6c0809af6e61"
+
+[[package]]
 name = "arr_macro"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -106,6 +112,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "bincode"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1f45e9417d87227c7a56d22e471c6206462cba514c7590c09aff4cf6d1ddcad"
+dependencies = [
+ "serde",
+]
+
+[[package]]
 name = "bstr"
 version = "1.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -130,11 +145,31 @@ checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
 
 [[package]]
 name = "colored"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
+dependencies = [
+ "lazy_static",
+ "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "colored"
 version = "3.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fde0e0ec90c9dfb3b4b1a0891a7dcd0e2bffde2f7efed5fe7c9bb00e5bfb915e"
 dependencies = [
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "ctor"
+version = "0.1.26"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d2301688392eb071b0bf1a37be05c469d3cc4dbbd95df672fe28ab021e6a096"
+dependencies = [
+ "quote",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -234,10 +269,52 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "65bc07b1a8bc7c85c5f2e110c476c7389b4554ba72af57d8445ea63a576b0876"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-channel"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2dff15bf788c671c1934e366d07e30c1814a8ef514e1af724a602e8a2fbe1b10"
+dependencies = [
+ "futures-core",
+ "futures-sink",
+]
+
+[[package]]
 name = "futures-core"
 version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f29059c0c2090612e8d742178b0580d2dc940c837851ad723096f87af6663e"
+
+[[package]]
+name = "futures-executor"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e28d1d997f585e54aebc3f97d39e72338912123a67330d723fdbb564d646c9f"
+dependencies = [
+ "futures-core",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
+name = "futures-io"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9e5c1b78ca4aae1ac06c48a526a655760685149f0d465d21f37abfe57ce075c6"
 
 [[package]]
 name = "futures-macro"
@@ -249,6 +326,12 @@ dependencies = [
  "quote",
  "syn 2.0.108",
 ]
+
+[[package]]
+name = "futures-sink"
+version = "0.3.31"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e575fab7d1e0dcb8d0c7bcf9a63ee213816ab51902e6d244a95819acacf1d4f7"
 
 [[package]]
 name = "futures-task"
@@ -268,9 +351,13 @@ version = "0.3.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9fa08315bb612088cc391249efdc3bc77536f16c91f6cf495e6fbe85b20a4a81"
 dependencies = [
+ "futures-channel",
  "futures-core",
+ "futures-io",
  "futures-macro",
+ "futures-sink",
  "futures-task",
+ "memchr",
  "pin-project-lite",
  "pin-utils",
  "slab",
@@ -295,6 +382,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
 
 [[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
 name = "indexmap"
 version = "2.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -309,6 +402,15 @@ name = "is_terminal_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+
+[[package]]
+name = "itertools"
+version = "0.10.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
+dependencies = [
+ "either",
+]
 
 [[package]]
 name = "itertools"
@@ -362,6 +464,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
+name = "libloading"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+dependencies = [
+ "cfg-if",
+ "windows-link",
+]
+
+[[package]]
 name = "log"
 version = "0.4.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -410,20 +522,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
 
 [[package]]
+name = "peresil"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f658886ed52e196e850cfbbfddab9eaa7f6d90dd0929e264c31e5cec07e09e57"
+
+[[package]]
 name = "phie"
 version = "0.0.0"
 dependencies = [
  "arr_macro",
  "assert_cmd",
- "ctor",
+ "ctor 0.6.0",
  "env_logger",
- "itertools",
+ "itertools 0.14.0",
  "lazy_static",
+ "libloading",
  "log",
  "predicates",
  "regex",
- "rstest",
- "simple_logger",
+ "rstest 0.26.1",
+ "simple_logger 5.1.0",
+ "sodg",
  "strum_macros",
 ]
 
@@ -521,6 +641,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "quick-error"
+version = "1.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1d01941d82fa2ab50be1e79e6714289dd7cde78eba4c074bc5a4374f650dfe0"
+
+[[package]]
 name = "quote"
 version = "1.0.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -566,13 +692,39 @@ checksum = "ba39f3699c378cd8970968dcbff9c43159ea4cfbd88d43c00b22f2ef10a435d2"
 
 [[package]]
 name = "rstest"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b07f2d176c472198ec1e6551dc7da28f1c089652f66a7b722676c2238ebc0edf"
+dependencies = [
+ "futures",
+ "futures-timer",
+ "rstest_macros 0.16.0",
+ "rustc_version",
+]
+
+[[package]]
+name = "rstest"
 version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f5a3193c063baaa2a95a33f03035c8a72b83d97a54916055ba22d35ed3839d49"
 dependencies = [
  "futures-timer",
  "futures-util",
- "rstest_macros",
+ "rstest_macros 0.26.1",
+]
+
+[[package]]
+name = "rstest_macros"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7229b505ae0706e64f37ffc54a9c163e11022a6636d58fe1f3f52018257ff9f7"
+dependencies = [
+ "cfg-if",
+ "proc-macro2",
+ "quote",
+ "rustc_version",
+ "syn 1.0.109",
+ "unicode-ident",
 ]
 
 [[package]]
@@ -615,6 +767,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
 dependencies = [
  "serde_core",
+ "serde_derive",
 ]
 
 [[package]]
@@ -639,11 +792,23 @@ dependencies = [
 
 [[package]]
 name = "simple_logger"
+version = "4.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e7e46c8c90251d47d08b28b8a419ffb4aede0f87c2eea95e17d1d5bacbf3ef1"
+dependencies = [
+ "colored 2.2.0",
+ "log",
+ "time",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
+name = "simple_logger"
 version = "5.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "291bee647ce7310b0ea721bfd7e0525517b4468eb7c7e15eb8bd774343179702"
 dependencies = [
- "colored",
+ "colored 3.0.0",
  "log",
  "time",
  "windows-sys 0.61.2",
@@ -656,6 +821,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2ae44ef20feb57a68b23d846850f861394c2e02dc425a50098ae8c90267589"
 
 [[package]]
+name = "sodg"
+version = "0.0.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a93247d55e07882155c63f5267d8f75ce1c52fd11a0f4db91ca88bd91803dfcc"
+dependencies = [
+ "anyhow",
+ "bincode",
+ "ctor 0.1.26",
+ "hex",
+ "itertools 0.10.5",
+ "lazy_static",
+ "log",
+ "regex",
+ "rstest 0.16.0",
+ "serde",
+ "simple_logger 4.3.3",
+ "sxd-document",
+ "sxd-xpath",
+ "xml-builder",
+]
+
+[[package]]
 name = "strum_macros"
 version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -665,6 +852,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.108",
+]
+
+[[package]]
+name = "sxd-document"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94d82f37be9faf1b10a82c4bd492b74f698e40082f0f40de38ab275f31d42078"
+dependencies = [
+ "peresil",
+ "typed-arena",
+]
+
+[[package]]
+name = "sxd-xpath"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "36e39da5d30887b5690e29de4c5ebb8ddff64ebd9933f98a01daaa4fd11b36ea"
+dependencies = [
+ "peresil",
+ "quick-error",
+ "sxd-document",
 ]
 
 [[package]]
@@ -759,6 +967,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "typed-arena"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9b2228007eba4120145f785df0f6c92ea538f5a3635a612ecf4e334c8c1446d"
+
+[[package]]
 name = "unicode-ident"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -787,6 +1001,15 @@ checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
 
 [[package]]
 name = "windows-sys"
+version = "0.48.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "677d2418bec65e3338edb076e806bc1ec15693c5d0104683f2efe857f61056a9"
+dependencies = [
+ "windows-targets 0.48.5",
+]
+
+[[package]]
+name = "windows-sys"
 version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e38bc4d79ed67fd075bcc251a1c39b32a1776bbe92e5bef1f0bf1f8c531853b"
@@ -810,6 +1033,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a2fa6e2155d7247be68c096456083145c183cbbbc2764150dda45a87197940c"
+dependencies = [
+ "windows_aarch64_gnullvm 0.48.5",
+ "windows_aarch64_msvc 0.48.5",
+ "windows_i686_gnu 0.48.5",
+ "windows_i686_msvc 0.48.5",
+ "windows_x86_64_gnu 0.48.5",
+ "windows_x86_64_gnullvm 0.48.5",
+ "windows_x86_64_msvc 0.48.5",
 ]
 
 [[package]]
@@ -847,6 +1085,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
@@ -859,6 +1103,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
@@ -868,6 +1118,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a75915e7def60c94dcef72200b9a8e58e5091744960da64ec734a6c6e9b3743e"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -895,6 +1151,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
@@ -904,6 +1166,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53d40abd2583d23e4718fddf1ebec84dbff8381c07cae67ff7768bbf19c6718e"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -919,6 +1187,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
@@ -928,6 +1202,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.48.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed94fce61571a4006852b7389a063ab983c02eb1bb37b47f8272ce92d06d9538"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -949,3 +1229,9 @@ checksum = "21a0236b59786fed61e2a80582dd500fe61f18b5dca67a4a067d0bc9039339cf"
 dependencies = [
  "memchr",
 ]
+
+[[package]]
+name = "xml-builder"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c023e38161c176b6ed516e2c398acd755cd19983661eff519b811c01646e10f"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "phie"
 version = "0.0.0"
-edition = "2021"
+edition = "2024"
 repository = "https://github.com/objectionary/phie"
 description = "Experimental emulator of a machine that understands 𝜑-calculus expressions"
 readme = "README.md"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,12 @@ readme = "README.md"
 license-file = "LICENSE.txt"
 homepage = "https://github.com/objectionary/phie"
 keywords = ["eolang", "compiler", "emulator", "oop"]
-categories = ["command-line-utilities", "development-tools", "emulators", "virtualization"]
+categories = [
+  "command-line-utilities",
+  "development-tools",
+  "emulators",
+  "virtualization",
+]
 
 [dependencies]
 regex = "1.12"
@@ -20,6 +25,8 @@ arr_macro = "0.2"
 log = "0.4"
 ctor = "0.6"
 rstest = "0.26"
+sodg = "0.0.32"
+libloading = "0.8"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/src/emu/transitions.rs
+++ b/src/emu/transitions.rs
@@ -82,7 +82,9 @@ impl Emu {
                     }
                     perf.tick(Transition::DEL);
                     for v in wbsk.kids.values() {
-                        if let Kid::Wait(b, _) = v && *b == bk {
+                        if let Kid::Wait(b, _) = v
+                            && *b == bk
+                        {
                             ready = false
                         }
                     }
@@ -217,7 +219,7 @@ impl Emu {
                                 loc,
                                 ob,
                                 join!(log)
-                            ))
+                            ));
                         }
                         Some((p, _psi)) => {
                             locs.insert(0, loc.clone());
@@ -240,7 +242,9 @@ impl Emu {
             ob = next;
             ret = Ok((next, psi, attr.clone()))
         };
-        if let Ok((next, _psi, _attr)) = ret.clone() && self.object(next).is_empty() {
+        if let Ok((next, _psi, _attr)) = ret.clone()
+            && self.object(next).is_empty()
+        {
             return Err(format!(
                 "Object ν{} is found by β{}.{}, but it's empty",
                 next, bk, locator

--- a/src/emu/transitions.rs
+++ b/src/emu/transitions.rs
@@ -41,10 +41,11 @@ impl Emu {
                     continue;
                 }
                 for k in bsk.kids.keys() {
-                    if let Some(Kid::Wait(b, l)) = &bsk.kids.get(k) {
-                        if *b == bk && *l == loc {
-                            changes.push((i as Bk, k.clone(), *d));
-                        }
+                    if let Some(Kid::Wait(b, l)) = &bsk.kids.get(k)
+                        && *b == bk
+                        && *l == loc
+                    {
+                        changes.push((i as Bk, k.clone(), *d));
                     }
                     perf.tick(Transition::PPG);
                 }
@@ -81,10 +82,8 @@ impl Emu {
                     }
                     perf.tick(Transition::DEL);
                     for v in wbsk.kids.values() {
-                        if let Kid::Wait(b, _) = v {
-                            if *b == bk {
-                                ready = false
-                            }
+                        if let Kid::Wait(b, _) = v && *b == bk {
+                            ready = false
                         }
                     }
                 }
@@ -101,17 +100,17 @@ impl Emu {
     /// Give control to the atom of the basket.
     pub fn delegate(&mut self, perf: &mut Perf, bk: Bk) {
         let bsk = self.basket(bk);
-        if let Some(Kid::Rqtd) = bsk.kids.get(&Loc::Phi) {
-            if !bsk.kids.values().any(|k| matches!(&k, Kid::Wait(_, _))) {
-                let obj = self.object(bsk.ob);
-                if let Some((n, func)) = &obj.lambda {
-                    let name = n.clone();
-                    perf.hit(Transition::DLG);
-                    if let Some(d) = func(self, bk) {
-                        perf.atom(name);
-                        let _ = &self.baskets[bk as usize].put(Loc::Phi, Kid::Dtzd(d));
-                        trace!("delegate(β{}) -> 0x{:04X}", bk, d);
-                    }
+        if let Some(Kid::Rqtd) = bsk.kids.get(&Loc::Phi)
+            && !bsk.kids.values().any(|k| matches!(&k, Kid::Wait(_, _)))
+        {
+            let obj = self.object(bsk.ob);
+            if let Some((n, func)) = &obj.lambda {
+                let name = n.clone();
+                perf.hit(Transition::DLG);
+                if let Some(d) = func(self, bk) {
+                    perf.atom(name);
+                    let _ = &self.baskets[bk as usize].put(Loc::Phi, Kid::Dtzd(d));
+                    trace!("delegate(β{}) -> 0x{:04X}", bk, d);
                 }
             }
         }
@@ -241,13 +240,11 @@ impl Emu {
             ob = next;
             ret = Ok((next, psi, attr.clone()))
         };
-        if let Ok((next, _psi, _attr)) = ret.clone() {
-            if self.object(next).is_empty() {
-                return Err(format!(
-                    "Object ν{} is found by β{}.{}, but it's empty",
-                    next, bk, locator
-                ));
-            }
+        if let Ok((next, _psi, _attr)) = ret.clone() && self.object(next).is_empty() {
+            return Err(format!(
+                "Object ν{} is found by β{}.{}, but it's empty",
+                next, bk, locator
+            ));
         }
         if let Ok((ob, psi, attr_opt)) = &ret {
             trace!(

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,6 +12,9 @@ pub mod loc;
 pub mod locator;
 pub mod object;
 pub mod perf;
+pub mod rust_atom;
+pub mod rust_engine;
+pub mod universe;
 
 #[cfg(test)]
 use simple_logger::SimpleLogger;

--- a/src/locator.rs
+++ b/src/locator.rs
@@ -223,9 +223,11 @@ fn fails_on_empty_locator() {
 fn fails_on_obj_not_at_first_position() {
     let result = Locator::from_str("P.ν5");
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .contains("can only stay at the first position"));
+    assert!(
+        result
+            .unwrap_err()
+            .contains("can only stay at the first position")
+    );
 }
 
 #[test]
@@ -246,9 +248,11 @@ fn fails_on_attr_at_start() {
 fn fails_on_obj_with_multiple_locs() {
     let result = Locator::from_str("ν5.0");
     assert!(result.is_err());
-    assert!(result
-        .unwrap_err()
-        .contains("can only be the first and only locator"));
+    assert!(
+        result
+            .unwrap_err()
+            .contains("can only be the first and only locator")
+    );
 }
 
 #[test]

--- a/src/rust_atom.rs
+++ b/src/rust_atom.rs
@@ -14,7 +14,7 @@ mod compilation;
 mod execution;
 
 pub use compilation::{compile, write_cargo_toml, write_lib_rs};
-pub use execution::{execute, RustAtomFn};
+pub use execution::{RustAtomFn, execute};
 
 use crate::data::Data;
 use crate::universe::Universe;
@@ -75,7 +75,11 @@ impl RustAtom {
     /// let atom = RustAtom::new("sum", "pub fn f() { }");
     /// ```
     pub fn new(id: &str, source: &str) -> Self {
-        RustAtom { id: id.to_string(), source: source.to_string(), lib_path: None }
+        RustAtom {
+            id: id.to_string(),
+            source: source.to_string(),
+            lib_path: None,
+        }
     }
 
     /// Compiles the Rust source code to a shared library.

--- a/src/rust_atom.rs
+++ b/src/rust_atom.rs
@@ -1,0 +1,209 @@
+//! Rust atom compilation and execution module.
+//!
+//! This module provides the infrastructure for compiling Rust source code
+//! into shared libraries and executing them as atoms within the phie runtime.
+//! It handles the complete pipeline from source code to executable function.
+//!
+//! The RustAtom struct coordinates between the compilation and execution
+//! subsystems, managing the lifecycle of dynamically loaded code.
+
+mod compilation;
+mod execution;
+
+pub use compilation::{compile, write_cargo_toml, write_lib_rs};
+pub use execution::{execute, RustAtomFn};
+
+use crate::data::Data;
+use crate::universe::Universe;
+use std::path::PathBuf;
+
+/// Represents a Rust atom with its source code and compilation state.
+///
+/// A RustAtom encapsulates all information needed to compile and execute
+/// a piece of Rust code as an atom. It manages:
+/// - Unique identification for the atom
+/// - Source code as a string
+/// - Path to the compiled shared library
+/// - Compilation process and error handling
+///
+/// # Compilation Process
+///
+/// Each atom is compiled into its own Cargo project with edition 2024
+/// and crate-type cdylib. The compilation produces a platform-specific
+/// shared library (.so on Linux, .dylib on macOS, .dll on Windows).
+///
+/// # Examples
+///
+/// ```no_run
+/// use phie::rust_atom::RustAtom;
+///
+/// let source = r#"
+/// #[no_mangle]
+/// pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
+///     42
+/// }
+/// "#;
+///
+/// let mut atom = RustAtom::new("my_atom", source);
+/// atom.compile("/tmp/build").unwrap();
+/// ```
+pub struct RustAtom {
+    /// Unique identifier for this atom
+    pub id: String,
+    /// Rust source code to be compiled
+    pub source: String,
+    /// Path to the compiled shared library, if compilation succeeded
+    pub lib_path: Option<PathBuf>,
+}
+
+impl RustAtom {
+    /// Creates a new RustAtom from source code.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique identifier for this atom
+    /// * `source` - Rust source code
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::rust_atom::RustAtom;
+    ///
+    /// let atom = RustAtom::new("sum", "pub fn f() { }");
+    /// ```
+    pub fn new(id: &str, source: &str) -> Self {
+        RustAtom { id: id.to_string(), source: source.to_string(), lib_path: None }
+    }
+
+    /// Compiles the Rust source code to a shared library.
+    ///
+    /// # Arguments
+    ///
+    /// * `build_dir` - Directory for build artifacts
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use phie::rust_atom::RustAtom;
+    ///
+    /// let mut atom = RustAtom::new("sum", "pub extern \"C\" fn f() -> i16 { 42 }");
+    /// atom.compile("/tmp/phie").unwrap();
+    /// ```
+    pub fn compile(&mut self, build_dir: &str) -> Result<PathBuf, String> {
+        let lib_path = compilation::compile(&self.id, &self.source, build_dir)?;
+        self.lib_path = Some(lib_path.clone());
+        Ok(lib_path)
+    }
+
+    /// Loads and executes the compiled Rust atom.
+    ///
+    /// # Arguments
+    ///
+    /// * `universe` - Universe instance for SODG operations
+    /// * `vertex` - Vertex ID to operate on
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the atom has not been compiled yet or if
+    /// execution fails.
+    pub fn execute(&self, universe: &mut Universe, vertex: u32) -> Result<Data, String> {
+        let lib_path = self.lib_path.as_ref().ok_or("Library not compiled")?;
+        execution::execute(lib_path, universe, vertex)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    #[test]
+    fn test_rust_atom_creation() {
+        let atom = RustAtom::new("test", "fn main() {}");
+        assert_eq!(atom.id, "test");
+        assert_eq!(atom.source, "fn main() {}");
+        assert!(atom.lib_path.is_none());
+    }
+
+    #[test]
+    fn test_new_atom_has_no_lib_path() {
+        let atom = RustAtom::new("test", "");
+        assert!(atom.lib_path.is_none());
+    }
+
+    #[test]
+    fn test_id_and_source_stored() {
+        let id = "my_atom";
+        let source = "fn test() {}";
+        let atom = RustAtom::new(id, source);
+        assert_eq!(atom.id, id);
+        assert_eq!(atom.source, source);
+    }
+
+    #[test]
+    fn test_execute_requires_compilation() {
+        let atom = RustAtom::new("not_compiled", "");
+        let mut uni = Universe::new();
+        let result = atom.execute(&mut uni, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not compiled"));
+    }
+
+    #[test]
+    fn test_compile_workflow() {
+        let source = r#"
+#[no_mangle]
+pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
+    42
+}
+"#;
+        let mut atom = RustAtom::new("workflow_test", source);
+        let temp_dir = std::env::temp_dir().join("phie_workflow_test");
+
+        let result = atom.compile(temp_dir.to_str().unwrap());
+
+        if result.is_ok() {
+            assert!(atom.lib_path.is_some());
+            assert!(atom.lib_path.as_ref().unwrap().exists());
+        }
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_execute_workflow() {
+        let source = r#"
+#[no_mangle]
+pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
+    100
+}
+"#;
+        let mut atom = RustAtom::new("exec_workflow", source);
+        let temp_dir = std::env::temp_dir().join("phie_exec_workflow");
+
+        if atom.compile(temp_dir.to_str().unwrap()).is_ok() {
+            let mut uni = Universe::new();
+            let result = atom.execute(&mut uni, 0);
+            if result.is_ok() {
+                assert_eq!(result.unwrap(), 100);
+            }
+        }
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_compile_sets_lib_path() {
+        let mut atom = RustAtom::new("lib_path_test", "pub extern \"C\" fn f() {}");
+        let temp_dir = std::env::temp_dir().join("phie_lib_path_test");
+
+        if atom.compile(temp_dir.to_str().unwrap()).is_ok() {
+            assert!(atom.lib_path.is_some());
+            let lib_path = atom.lib_path.unwrap();
+            assert!(lib_path.exists());
+            assert!(lib_path.to_string_lossy().contains("lib_path_test"));
+        }
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+}

--- a/src/rust_atom.rs
+++ b/src/rust_atom.rs
@@ -166,14 +166,11 @@ pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
 "#;
         let mut atom = RustAtom::new("workflow_test", source);
         let temp_dir = std::env::temp_dir().join("phie_workflow_test");
-
         let result = atom.compile(temp_dir.to_str().unwrap());
-
         if result.is_ok() {
             assert!(atom.lib_path.is_some());
             assert!(atom.lib_path.as_ref().unwrap().exists());
         }
-
         fs::remove_dir_all(&temp_dir).ok();
     }
 
@@ -187,7 +184,6 @@ pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
 "#;
         let mut atom = RustAtom::new("exec_workflow", source);
         let temp_dir = std::env::temp_dir().join("phie_exec_workflow");
-
         if atom.compile(temp_dir.to_str().unwrap()).is_ok() {
             let mut uni = Universe::new();
             let result = atom.execute(&mut uni, 0);
@@ -195,7 +191,6 @@ pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
                 assert_eq!(result.unwrap(), 100);
             }
         }
-
         fs::remove_dir_all(&temp_dir).ok();
     }
 
@@ -203,14 +198,12 @@ pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
     fn test_compile_sets_lib_path() {
         let mut atom = RustAtom::new("lib_path_test", "pub extern \"C\" fn f() {}");
         let temp_dir = std::env::temp_dir().join("phie_lib_path_test");
-
         if atom.compile(temp_dir.to_str().unwrap()).is_ok() {
             assert!(atom.lib_path.is_some());
             let lib_path = atom.lib_path.unwrap();
             assert!(lib_path.exists());
             assert!(lib_path.to_string_lossy().contains("lib_path_test"));
         }
-
         fs::remove_dir_all(&temp_dir).ok();
     }
 }

--- a/src/rust_atom.rs
+++ b/src/rust_atom.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
 //! Rust atom compilation and execution module.
 //!
 //! This module provides the infrastructure for compiling Rust source code

--- a/src/rust_atom/compilation.rs
+++ b/src/rust_atom/compilation.rs
@@ -136,7 +136,8 @@ pub fn write_lib_rs(dir: &Path, source: &str) -> Result<(), String> {
 
     let mut file = fs::File::create(src_dir.join("lib.rs"))
         .map_err(|e| format!("Failed to create lib.rs: {e}"))?;
-    file.write_all(source.as_bytes()).map_err(|e| format!("Failed to write lib.rs: {e}"))?;
+    file.write_all(source.as_bytes())
+        .map_err(|e| format!("Failed to write lib.rs: {e}"))?;
     Ok(())
 }
 

--- a/src/rust_atom/compilation.rs
+++ b/src/rust_atom/compilation.rs
@@ -1,0 +1,260 @@
+//! Compilation of Rust source code to shared libraries.
+//!
+//! This module handles the complete compilation pipeline for Rust atoms:
+//! - Creating isolated Cargo projects with proper configuration
+//! - Writing source files and build manifests
+//! - Invoking cargo to build cdylib shared libraries
+//! - Platform-specific library naming and location
+//!
+//! Each atom is compiled in its own directory with edition 2024 and
+//! crate-type cdylib for dynamic loading.
+
+use std::fs;
+use std::io::Write;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+/// Compiles Rust source code to a shared library.
+///
+/// Creates a complete Cargo project structure in the specified build
+/// directory, compiles the source code, and returns the path to the
+/// resulting shared library (.so on Linux, .dylib on macOS, .dll on Windows).
+///
+/// # Arguments
+///
+/// * `id` - Unique identifier for the atom (used as crate name)
+/// * `source` - Rust source code to compile
+/// * `build_dir` - Directory for build artifacts
+///
+/// # Returns
+///
+/// Path to the compiled shared library
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - Build directory cannot be created
+/// - File writing fails
+/// - Cargo compilation fails
+/// - Compiled library is not found
+///
+/// # Examples
+///
+/// ```no_run
+/// use phie::rust_atom::compilation::compile;
+///
+/// let source = r#"
+/// #[no_mangle]
+/// pub extern "C" fn f() -> i16 { 42 }
+/// "#;
+/// let lib_path = compile("my_atom", source, "/tmp/build").unwrap();
+/// ```
+pub fn compile(id: &str, source: &str, build_dir: &str) -> Result<PathBuf, String> {
+    let build_path = Path::new(build_dir);
+    fs::create_dir_all(build_path).map_err(|e| format!("Failed to create build dir: {}", e))?;
+
+    let atom_dir = build_path.join(id);
+    fs::create_dir_all(&atom_dir).map_err(|e| format!("Failed to create atom dir: {}", e))?;
+
+    write_cargo_toml(&atom_dir, id)?;
+    write_lib_rs(&atom_dir, source)?;
+
+    let output = Command::new("cargo")
+        .args(["build", "--release", "--manifest-path"])
+        .arg(atom_dir.join("Cargo.toml"))
+        .output()
+        .map_err(|e| format!("Failed to run cargo: {}", e))?;
+
+    if !output.status.success() {
+        return Err(format!("Compilation failed: {}", String::from_utf8_lossy(&output.stderr)));
+    }
+
+    let lib_name = get_library_name(id);
+    let lib_path = atom_dir.join("target/release").join(&lib_name);
+
+    if !lib_path.exists() {
+        return Err(format!("Library not found: {}", lib_path.display()));
+    }
+
+    Ok(lib_path)
+}
+
+/// Writes Cargo.toml manifest for the atom.
+///
+/// Creates a minimal Cargo.toml with edition 2024 and cdylib crate type.
+///
+/// # Arguments
+///
+/// * `dir` - Directory to write Cargo.toml in
+/// * `id` - Crate name for the atom
+///
+/// # Errors
+///
+/// Returns an error if file creation or writing fails.
+pub fn write_cargo_toml(dir: &Path, id: &str) -> Result<(), String> {
+    let content = format!(
+        r#"[package]
+name = "{}"
+version = "0.1.0"
+edition = "2024"
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+"#,
+        id
+    );
+
+    let mut file = fs::File::create(dir.join("Cargo.toml"))
+        .map_err(|e| format!("Failed to create Cargo.toml: {}", e))?;
+    file.write_all(content.as_bytes())
+        .map_err(|e| format!("Failed to write Cargo.toml: {}", e))?;
+    Ok(())
+}
+
+/// Writes lib.rs source file for the atom.
+///
+/// Creates src/lib.rs with the provided source code.
+///
+/// # Arguments
+///
+/// * `dir` - Directory to write source in (will create src/ subdir)
+/// * `source` - Rust source code
+///
+/// # Errors
+///
+/// Returns an error if directory or file creation fails.
+pub fn write_lib_rs(dir: &Path, source: &str) -> Result<(), String> {
+    let src_dir = dir.join("src");
+    fs::create_dir_all(&src_dir).map_err(|e| format!("Failed to create src dir: {}", e))?;
+
+    let mut file = fs::File::create(src_dir.join("lib.rs"))
+        .map_err(|e| format!("Failed to create lib.rs: {}", e))?;
+    file.write_all(source.as_bytes()).map_err(|e| format!("Failed to write lib.rs: {}", e))?;
+    Ok(())
+}
+
+/// Returns the platform-specific shared library filename.
+///
+/// # Arguments
+///
+/// * `id` - Atom identifier
+///
+/// # Returns
+///
+/// Library filename:
+/// - Linux: "lib{id}.so"
+/// - macOS: "lib{id}.dylib"
+/// - Windows: "{id}.dll"
+fn get_library_name(id: &str) -> String {
+    if cfg!(target_os = "linux") {
+        format!("lib{}.so", id)
+    } else if cfg!(target_os = "macos") {
+        format!("lib{}.dylib", id)
+    } else {
+        format!("{}.dll", id)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_get_library_name() {
+        let name = get_library_name("test");
+        if cfg!(target_os = "linux") {
+            assert_eq!(name, "libtest.so");
+        } else if cfg!(target_os = "macos") {
+            assert_eq!(name, "libtest.dylib");
+        } else {
+            assert_eq!(name, "test.dll");
+        }
+    }
+
+    #[test]
+    fn test_write_cargo_toml() {
+        let temp_dir = std::env::temp_dir().join("phie_test_cargo_write");
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        write_cargo_toml(&temp_dir, "test_crate").unwrap();
+
+        let cargo_path = temp_dir.join("Cargo.toml");
+        assert!(cargo_path.exists());
+
+        let content = fs::read_to_string(cargo_path).unwrap();
+        assert!(content.contains("name = \"test_crate\""));
+        assert!(content.contains("edition = \"2024\""));
+        assert!(content.contains("crate-type = [\"cdylib\"]"));
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_write_lib_rs() {
+        let temp_dir = std::env::temp_dir().join("phie_test_lib_write");
+        fs::create_dir_all(&temp_dir).unwrap();
+
+        let source = "pub fn hello() { println!(\"test\"); }";
+        write_lib_rs(&temp_dir, source).unwrap();
+
+        let lib_path = temp_dir.join("src/lib.rs");
+        assert!(lib_path.exists());
+
+        let content = fs::read_to_string(lib_path).unwrap();
+        assert_eq!(content, source);
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_compile_integration() {
+        let source = r#"
+#[no_mangle]
+pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
+    42
+}
+"#;
+        let temp_dir = std::env::temp_dir().join("phie_test_compile_int");
+
+        let result = compile("compile_test", source, temp_dir.to_str().unwrap());
+
+        if let Ok(lib_path) = result {
+            assert!(lib_path.exists());
+            let filename = lib_path.file_name().unwrap().to_str().unwrap();
+            assert!(filename.contains("compile_test"));
+        }
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_compile_creates_structure() {
+        let source = "pub extern \"C\" fn f() {}";
+        let temp_dir = std::env::temp_dir().join("phie_test_structure");
+
+        if compile("structure_test", source, temp_dir.to_str().unwrap()).is_ok() {
+            let atom_dir = temp_dir.join("structure_test");
+            assert!(atom_dir.exists());
+            assert!(atom_dir.join("Cargo.toml").exists());
+            assert!(atom_dir.join("src/lib.rs").exists());
+        }
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+
+    #[test]
+    fn test_compile_invalid_source() {
+        let invalid_source = "this is not valid rust";
+        let temp_dir = std::env::temp_dir().join("phie_test_invalid");
+
+        let result = compile("invalid", invalid_source, temp_dir.to_str().unwrap());
+
+        if Command::new("cargo").arg("--version").output().is_ok() {
+            assert!(result.is_err());
+        }
+
+        fs::remove_dir_all(&temp_dir).ok();
+    }
+}

--- a/src/rust_atom/compilation.rs
+++ b/src/rust_atom/compilation.rs
@@ -54,10 +54,10 @@ use std::process::Command;
 /// ```
 pub fn compile(id: &str, source: &str, build_dir: &str) -> Result<PathBuf, String> {
     let build_path = Path::new(build_dir);
-    fs::create_dir_all(build_path).map_err(|e| format!("Failed to create build dir: {}", e))?;
+    fs::create_dir_all(build_path).map_err(|e| format!("Failed to create build dir: {e}"))?;
 
     let atom_dir = build_path.join(id);
-    fs::create_dir_all(&atom_dir).map_err(|e| format!("Failed to create atom dir: {}", e))?;
+    fs::create_dir_all(&atom_dir).map_err(|e| format!("Failed to create atom dir: {e}"))?;
 
     write_cargo_toml(&atom_dir, id)?;
     write_lib_rs(&atom_dir, source)?;
@@ -66,17 +66,19 @@ pub fn compile(id: &str, source: &str, build_dir: &str) -> Result<PathBuf, Strin
         .args(["build", "--release", "--manifest-path"])
         .arg(atom_dir.join("Cargo.toml"))
         .output()
-        .map_err(|e| format!("Failed to run cargo: {}", e))?;
+        .map_err(|e| format!("Failed to run cargo: {e}"))?;
 
     if !output.status.success() {
-        return Err(format!("Compilation failed: {}", String::from_utf8_lossy(&output.stderr)));
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(format!("Compilation failed: {stderr}"));
     }
 
     let lib_name = get_library_name(id);
     let lib_path = atom_dir.join("target/release").join(&lib_name);
 
     if !lib_path.exists() {
-        return Err(format!("Library not found: {}", lib_path.display()));
+        let path = lib_path.display();
+        return Err(format!("Library not found: {path}"));
     }
 
     Ok(lib_path)
@@ -110,9 +112,9 @@ crate-type = ["cdylib"]
     );
 
     let mut file = fs::File::create(dir.join("Cargo.toml"))
-        .map_err(|e| format!("Failed to create Cargo.toml: {}", e))?;
+        .map_err(|e| format!("Failed to create Cargo.toml: {e}"))?;
     file.write_all(content.as_bytes())
-        .map_err(|e| format!("Failed to write Cargo.toml: {}", e))?;
+        .map_err(|e| format!("Failed to write Cargo.toml: {e}"))?;
     Ok(())
 }
 
@@ -130,11 +132,11 @@ crate-type = ["cdylib"]
 /// Returns an error if directory or file creation fails.
 pub fn write_lib_rs(dir: &Path, source: &str) -> Result<(), String> {
     let src_dir = dir.join("src");
-    fs::create_dir_all(&src_dir).map_err(|e| format!("Failed to create src dir: {}", e))?;
+    fs::create_dir_all(&src_dir).map_err(|e| format!("Failed to create src dir: {e}"))?;
 
     let mut file = fs::File::create(src_dir.join("lib.rs"))
-        .map_err(|e| format!("Failed to create lib.rs: {}", e))?;
-    file.write_all(source.as_bytes()).map_err(|e| format!("Failed to write lib.rs: {}", e))?;
+        .map_err(|e| format!("Failed to create lib.rs: {e}"))?;
+    file.write_all(source.as_bytes()).map_err(|e| format!("Failed to write lib.rs: {e}"))?;
     Ok(())
 }
 
@@ -152,11 +154,11 @@ pub fn write_lib_rs(dir: &Path, source: &str) -> Result<(), String> {
 /// - Windows: "{id}.dll"
 fn get_library_name(id: &str) -> String {
     if cfg!(target_os = "linux") {
-        format!("lib{}.so", id)
+        format!("lib{id}.so")
     } else if cfg!(target_os = "macos") {
-        format!("lib{}.dylib", id)
+        format!("lib{id}.dylib")
     } else {
-        format!("{}.dll", id)
+        format!("{id}.dll")
     }
 }
 

--- a/src/rust_atom/compilation.rs
+++ b/src/rust_atom/compilation.rs
@@ -44,7 +44,7 @@ use std::process::Command;
 /// # Examples
 ///
 /// ```no_run
-/// use phie::rust_atom::compilation::compile;
+/// use phie::rust_atom::compile;
 ///
 /// let source = r#"
 /// #[no_mangle]

--- a/src/rust_atom/compilation.rs
+++ b/src/rust_atom/compilation.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
 //! Compilation of Rust source code to shared libraries.
 //!
 //! This module handles the complete compilation pipeline for Rust atoms:

--- a/src/rust_atom/execution.rs
+++ b/src/rust_atom/execution.rs
@@ -1,0 +1,107 @@
+//! Dynamic loading and execution of compiled Rust atoms.
+//!
+//! This module handles loading shared libraries at runtime via libloading
+//! and provides safe FFI wrappers for executing atom functions. The execution
+//! interface bridges between phie's Universe and the compiled Rust code.
+
+use crate::data::Data;
+use crate::universe::Universe;
+use std::path::Path;
+
+/// Function signature for compiled Rust atom entry points.
+///
+/// Compiled atoms must expose a function with C ABI that accepts:
+/// - A mutable pointer to Universe for graph operations
+/// - A vertex ID (u32) indicating the current execution context
+///
+/// Returns i16 (Data) representing the computed result.
+///
+/// # Safety
+///
+/// This is an unsafe extern C function pointer. Callers must ensure:
+/// - The Universe pointer is valid and properly aligned
+/// - The Universe is not accessed from multiple threads simultaneously
+/// - The vertex ID is valid within the current graph
+/// - The lifetime of the Universe exceeds the function call
+pub type RustAtomFn = unsafe extern "C" fn(*mut Universe, u32) -> i16;
+
+/// Loads and executes a compiled Rust atom.
+///
+/// Dynamically loads the shared library at the given path, finds the
+/// entry point function named "f", and executes it with the provided
+/// Universe and vertex ID.
+///
+/// # Arguments
+///
+/// * `lib_path` - Path to the compiled shared library
+/// * `universe` - Mutable reference to Universe for graph operations
+/// * `vertex` - Vertex ID for the execution context
+///
+/// # Returns
+///
+/// The i16 result value returned by the atom function
+///
+/// # Errors
+///
+/// Returns an error if:
+/// - The library file doesn't exist or cannot be loaded
+/// - The "f" function symbol is not found
+/// - The function signature is incorrect
+///
+/// # Safety
+///
+/// This function performs unsafe operations:
+/// - Dynamic library loading
+/// - Symbol resolution
+/// - FFI function call with raw pointers
+///
+/// The caller must ensure the library is compatible and trustworthy.
+///
+/// # Examples
+///
+/// ```no_run
+/// use phie::rust_atom::execution::execute;
+/// use phie::universe::Universe;
+/// use std::path::Path;
+///
+/// let mut universe = Universe::new();
+/// let result = execute(Path::new("/tmp/atom.so"), &mut universe, 0);
+/// ```
+pub fn execute(lib_path: &Path, universe: &mut Universe, vertex: u32) -> Result<Data, String> {
+    if !lib_path.exists() {
+        return Err(format!("Library not found: {}", lib_path.display()));
+    }
+
+    unsafe {
+        let lib = libloading::Library::new(lib_path)
+            .map_err(|e| format!("Failed to load library: {}", e))?;
+
+        let func: libloading::Symbol<RustAtomFn> =
+            lib.get(b"f").map_err(|e| format!("Failed to find function f: {}", e))?;
+
+        let result = func(universe as *mut Universe, vertex);
+        Ok(result)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+
+    #[test]
+    fn test_execute_nonexistent_library() {
+        let mut universe = Universe::new();
+        let result = execute(Path::new("/nonexistent/lib.so"), &mut universe, 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn test_execute_requires_valid_path() {
+        let mut universe = Universe::new();
+        let invalid_path = PathBuf::from("/tmp/does_not_exist_phie_test.so");
+        let result = execute(&invalid_path, &mut universe, 0);
+        assert!(result.is_err());
+    }
+}

--- a/src/rust_atom/execution.rs
+++ b/src/rust_atom/execution.rs
@@ -72,15 +72,16 @@ pub type RustAtomFn = unsafe extern "C" fn(*mut Universe, u32) -> i16;
 /// ```
 pub fn execute(lib_path: &Path, universe: &mut Universe, vertex: u32) -> Result<Data, String> {
     if !lib_path.exists() {
-        return Err(format!("Library not found: {}", lib_path.display()));
+        let path = lib_path.display();
+        return Err(format!("Library not found: {path}"));
     }
 
     unsafe {
         let lib = libloading::Library::new(lib_path)
-            .map_err(|e| format!("Failed to load library: {}", e))?;
+            .map_err(|e| format!("Failed to load library: {e}"))?;
 
         let func: libloading::Symbol<RustAtomFn> =
-            lib.get(b"f").map_err(|e| format!("Failed to find function f: {}", e))?;
+            lib.get(b"f").map_err(|e| format!("Failed to find function f: {e}"))?;
 
         let result = func(universe as *mut Universe, vertex);
         Ok(result)

--- a/src/rust_atom/execution.rs
+++ b/src/rust_atom/execution.rs
@@ -80,8 +80,9 @@ pub fn execute(lib_path: &Path, universe: &mut Universe, vertex: u32) -> Result<
         let lib = libloading::Library::new(lib_path)
             .map_err(|e| format!("Failed to load library: {e}"))?;
 
-        let func: libloading::Symbol<RustAtomFn> =
-            lib.get(b"f").map_err(|e| format!("Failed to find function f: {e}"))?;
+        let func: libloading::Symbol<RustAtomFn> = lib
+            .get(b"f")
+            .map_err(|e| format!("Failed to find function f: {e}"))?;
 
         let result = func(universe as *mut Universe, vertex);
         Ok(result)

--- a/src/rust_atom/execution.rs
+++ b/src/rust_atom/execution.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
 //! Dynamic loading and execution of compiled Rust atoms.
 //!
 //! This module handles loading shared libraries at runtime via libloading

--- a/src/rust_atom/execution.rs
+++ b/src/rust_atom/execution.rs
@@ -75,15 +75,12 @@ pub fn execute(lib_path: &Path, universe: &mut Universe, vertex: u32) -> Result<
         let path = lib_path.display();
         return Err(format!("Library not found: {path}"));
     }
-
     unsafe {
         let lib = libloading::Library::new(lib_path)
             .map_err(|e| format!("Failed to load library: {e}"))?;
-
         let func: libloading::Symbol<RustAtomFn> = lib
             .get(b"f")
             .map_err(|e| format!("Failed to find function f: {e}"))?;
-
         let result = func(universe as *mut Universe, vertex);
         Ok(result)
     }

--- a/src/rust_atom/execution.rs
+++ b/src/rust_atom/execution.rs
@@ -63,7 +63,7 @@ pub type RustAtomFn = unsafe extern "C" fn(*mut Universe, u32) -> i16;
 /// # Examples
 ///
 /// ```no_run
-/// use phie::rust_atom::execution::execute;
+/// use phie::rust_atom::execute;
 /// use phie::universe::Universe;
 /// use std::path::Path;
 ///

--- a/src/rust_engine.rs
+++ b/src/rust_engine.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
 //! Rust atom execution engine with compilation caching and Universe management.
 //!
 //! This module provides a high-level engine for managing multiple Rust atoms

--- a/src/rust_engine.rs
+++ b/src/rust_engine.rs
@@ -119,7 +119,7 @@ impl RustEngine {
     /// engine.compile("sum").unwrap();
     /// ```
     pub fn compile(&mut self, id: &str) -> Result<(), String> {
-        let atom = self.atoms.get_mut(id).ok_or_else(|| format!("Atom {} not found", id))?;
+        let atom = self.atoms.get_mut(id).ok_or_else(|| format!("Atom {id} not found"))?;
 
         atom.compile(self.build_dir.to_str().ok_or("Invalid build dir")?)?;
         Ok(())
@@ -132,12 +132,12 @@ impl RustEngine {
     /// * `id` - Atom identifier
     /// * `vertex` - Vertex ID for operations
     pub fn execute(&self, id: &str, vertex: u32) -> Result<Data, String> {
-        let atom = self.atoms.get(id).ok_or_else(|| format!("Atom {} not found", id))?;
+        let atom = self.atoms.get(id).ok_or_else(|| format!("Atom {id} not found"))?;
 
         let mut uni = self
             .universe
             .lock()
-            .map_err(|e| format!("Lock error: {}", e))?;
+            .map_err(|e| format!("Lock error: {e}"))?;
         atom.execute(&mut uni, vertex)
     }
 

--- a/src/rust_engine.rs
+++ b/src/rust_engine.rs
@@ -123,7 +123,6 @@ impl RustEngine {
             .atoms
             .get_mut(id)
             .ok_or_else(|| format!("Atom {id} not found"))?;
-
         atom.compile(self.build_dir.to_str().ok_or("Invalid build dir")?)?;
         Ok(())
     }
@@ -139,7 +138,6 @@ impl RustEngine {
             .atoms
             .get(id)
             .ok_or_else(|| format!("Atom {id} not found"))?;
-
         let mut uni = self
             .universe
             .lock()
@@ -198,7 +196,6 @@ pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
 }
 "#;
         let result = engine.compile_and_execute("integration", source, 0);
-
         if result.is_ok() {
             assert_eq!(result.unwrap(), 999);
         }
@@ -209,9 +206,7 @@ pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
         let mut engine = RustEngine::new("/tmp/phie_compile_flow");
         let source = "pub extern \"C\" fn f() {}";
         engine.register("flow_test", source);
-
         assert!(engine.atoms.contains_key("flow_test"));
-
         if engine.compile("flow_test").is_ok() {
             assert!(engine.atoms.get("flow_test").unwrap().lib_path.is_some());
         }
@@ -227,7 +222,6 @@ pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
 }
 "#;
         engine.register("exec_flow", source);
-
         if engine.compile("exec_flow").is_ok() {
             let result = engine.execute("exec_flow", 0);
             if result.is_ok() {

--- a/src/rust_engine.rs
+++ b/src/rust_engine.rs
@@ -119,7 +119,10 @@ impl RustEngine {
     /// engine.compile("sum").unwrap();
     /// ```
     pub fn compile(&mut self, id: &str) -> Result<(), String> {
-        let atom = self.atoms.get_mut(id).ok_or_else(|| format!("Atom {id} not found"))?;
+        let atom = self
+            .atoms
+            .get_mut(id)
+            .ok_or_else(|| format!("Atom {id} not found"))?;
 
         atom.compile(self.build_dir.to_str().ok_or("Invalid build dir")?)?;
         Ok(())
@@ -132,7 +135,10 @@ impl RustEngine {
     /// * `id` - Atom identifier
     /// * `vertex` - Vertex ID for operations
     pub fn execute(&self, id: &str, vertex: u32) -> Result<Data, String> {
-        let atom = self.atoms.get(id).ok_or_else(|| format!("Atom {id} not found"))?;
+        let atom = self
+            .atoms
+            .get(id)
+            .ok_or_else(|| format!("Atom {id} not found"))?;
 
         let mut uni = self
             .universe

--- a/src/rust_engine.rs
+++ b/src/rust_engine.rs
@@ -1,0 +1,278 @@
+//! Rust atom execution engine with compilation caching and Universe management.
+//!
+//! This module provides a high-level engine for managing multiple Rust atoms
+//! within a single phie execution context. The RustEngine coordinates:
+//! - Registration of Rust atoms by unique identifiers
+//! - Lazy compilation of atoms only when needed
+//! - Caching of compiled shared libraries for reuse
+//! - Thread-safe access to a shared Universe instance
+//! - Execution of compiled atoms with proper error handling
+//!
+//! The engine maintains a single Universe instance wrapped in Arc<Mutex<>>
+//! to allow safe concurrent access from multiple compiled atoms while
+//! ensuring data consistency.
+
+use crate::data::Data;
+use crate::rust_atom::RustAtom;
+use crate::universe::Universe;
+
+use std::collections::HashMap;
+use std::path::PathBuf;
+use std::sync::{Arc, Mutex};
+
+/// High-level engine for managing Rust atom lifecycle.
+///
+/// RustEngine provides a centralized manager for:
+/// - Atom registration: storing source code with unique IDs
+/// - Compilation: building atoms into shared libraries
+/// - Execution: loading and calling compiled atom functions
+/// - Universe sharing: providing thread-safe access to SODG graph
+///
+/// The engine stores atoms in a HashMap keyed by their unique identifiers.
+/// Each atom can be compiled independently and executed multiple times.
+/// The shared Universe ensures all atoms operate on the same object graph.
+///
+/// # Thread Safety
+///
+/// The Universe is wrapped in Arc<Mutex<>> to allow safe access from
+/// multiple atoms. The atoms HashMap itself is not thread-safe and
+/// should be accessed from a single thread during compilation phase.
+///
+/// # Examples
+///
+/// ```no_run
+/// use phie::rust_engine::RustEngine;
+///
+/// let mut engine = RustEngine::new("/tmp/phie");
+/// engine.register("sum", "pub extern \"C\" fn f() -> i16 { 42 }");
+/// engine.compile("sum").unwrap();
+/// let result = engine.execute("sum", 0).unwrap();
+/// assert_eq!(result, 42);
+/// ```
+pub struct RustEngine {
+    /// Registered atoms indexed by unique identifier
+    atoms: HashMap<String, RustAtom>,
+    /// Directory for build artifacts and compilation output
+    build_dir: PathBuf,
+    /// Shared Universe instance accessible to all atoms
+    universe: Arc<Mutex<Universe>>,
+}
+
+impl RustEngine {
+    /// Creates a new RustEngine with a build directory.
+    ///
+    /// # Arguments
+    ///
+    /// * `build_dir` - Directory for build artifacts
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::rust_engine::RustEngine;
+    ///
+    /// let engine = RustEngine::new("/tmp/phie");
+    /// ```
+    pub fn new(build_dir: &str) -> Self {
+        RustEngine {
+            atoms: HashMap::new(),
+            build_dir: PathBuf::from(build_dir),
+            universe: Arc::new(Mutex::new(Universe::new())),
+        }
+    }
+
+    /// Registers a Rust atom from source code.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Unique identifier for the atom
+    /// * `source` - Rust source code
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::rust_engine::RustEngine;
+    ///
+    /// let mut engine = RustEngine::new("/tmp/phie");
+    /// engine.register("sum", "pub extern \"C\" fn f() -> i16 { 42 }");
+    /// ```
+    pub fn register(&mut self, id: &str, source: &str) {
+        let atom = RustAtom::new(id, source);
+        self.atoms.insert(id.to_string(), atom);
+    }
+
+    /// Compiles a registered Rust atom.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Atom identifier
+    ///
+    /// # Examples
+    ///
+    /// ```no_run
+    /// use phie::rust_engine::RustEngine;
+    ///
+    /// let mut engine = RustEngine::new("/tmp/phie");
+    /// engine.register("sum", "pub extern \"C\" fn f() -> i16 { 42 }");
+    /// engine.compile("sum").unwrap();
+    /// ```
+    pub fn compile(&mut self, id: &str) -> Result<(), String> {
+        let atom = self.atoms.get_mut(id).ok_or_else(|| format!("Atom {} not found", id))?;
+
+        atom.compile(self.build_dir.to_str().ok_or("Invalid build dir")?)?;
+        Ok(())
+    }
+
+    /// Executes a compiled Rust atom.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Atom identifier
+    /// * `vertex` - Vertex ID for operations
+    pub fn execute(&self, id: &str, vertex: u32) -> Result<Data, String> {
+        let atom = self.atoms.get(id).ok_or_else(|| format!("Atom {} not found", id))?;
+
+        let mut uni = self.universe.lock().map_err(|e| format!("Lock error: {}", e))?;
+        atom.execute(&mut uni, vertex)
+    }
+
+    /// Compiles and executes a Rust atom in one call.
+    ///
+    /// # Arguments
+    ///
+    /// * `id` - Atom identifier
+    /// * `source` - Rust source code
+    /// * `vertex` - Vertex ID for operations
+    pub fn compile_and_execute(
+        &mut self,
+        id: &str,
+        source: &str,
+        vertex: u32,
+    ) -> Result<Data, String> {
+        self.register(id, source);
+        self.compile(id)?;
+        self.execute(id, vertex)
+    }
+
+    /// Returns a reference to the Universe for direct manipulation.
+    pub fn universe(&self) -> Arc<Mutex<Universe>> {
+        Arc::clone(&self.universe)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_engine_creation() {
+        let engine = RustEngine::new("/tmp/phie_test");
+        assert!(engine.atoms.is_empty());
+    }
+
+    #[test]
+    fn test_register_atom() {
+        let mut engine = RustEngine::new("/tmp/phie_test");
+        engine.register("test", "fn main() {}");
+        assert!(engine.atoms.contains_key("test"));
+    }
+
+    #[test]
+    fn test_compile_and_execute_integration() {
+        let mut engine = RustEngine::new("/tmp/phie_engine_integration");
+        let source = r#"
+#[no_mangle]
+pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
+    999
+}
+"#;
+        let result = engine.compile_and_execute("integration", source, 0);
+
+        if result.is_ok() {
+            assert_eq!(result.unwrap(), 999);
+        }
+    }
+
+    #[test]
+    fn test_compile_workflow() {
+        let mut engine = RustEngine::new("/tmp/phie_compile_flow");
+        let source = "pub extern \"C\" fn f() {}";
+        engine.register("flow_test", source);
+
+        assert!(engine.atoms.contains_key("flow_test"));
+
+        if engine.compile("flow_test").is_ok() {
+            assert!(engine.atoms.get("flow_test").unwrap().lib_path.is_some());
+        }
+    }
+
+    #[test]
+    fn test_execute_workflow() {
+        let mut engine = RustEngine::new("/tmp/phie_execute_flow");
+        let source = r#"
+#[no_mangle]
+pub extern "C" fn f(_uni: *mut u8, _v: u32) -> i16 {
+    777
+}
+"#;
+        engine.register("exec_flow", source);
+
+        if engine.compile("exec_flow").is_ok() {
+            let result = engine.execute("exec_flow", 0);
+            if result.is_ok() {
+                assert_eq!(result.unwrap(), 777);
+            }
+        }
+    }
+
+    #[test]
+    fn test_compile_nonexistent_atom() {
+        let mut engine = RustEngine::new("/tmp/phie_test");
+        let result = engine.compile("nonexistent");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn test_execute_nonexistent_atom() {
+        let engine = RustEngine::new("/tmp/phie_test");
+        let result = engine.execute("nonexistent", 0);
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("not found"));
+    }
+
+    #[test]
+    fn test_execute_uncompiled_atom() {
+        let mut engine = RustEngine::new("/tmp/phie_test");
+        engine.register("uncompiled", "fn test() {}");
+        let result = engine.execute("uncompiled", 0);
+        assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_multiple_atoms() {
+        let mut engine = RustEngine::new("/tmp/phie_multi_test");
+        engine.register("atom1", "fn a() {}");
+        engine.register("atom2", "fn b() {}");
+        engine.register("atom3", "fn c() {}");
+        assert_eq!(engine.atoms.len(), 3);
+        assert!(engine.atoms.contains_key("atom1"));
+        assert!(engine.atoms.contains_key("atom2"));
+        assert!(engine.atoms.contains_key("atom3"));
+    }
+
+    #[test]
+    fn test_universe_sharing() {
+        let engine = RustEngine::new("/tmp/phie_test");
+        let uni1 = engine.universe();
+        let uni2 = engine.universe();
+        assert!(Arc::ptr_eq(&uni1, &uni2));
+    }
+
+    #[test]
+    fn test_register_overwrites() {
+        let mut engine = RustEngine::new("/tmp/phie_test");
+        engine.register("test", "first");
+        engine.register("test", "second");
+        assert_eq!(engine.atoms.get("test").unwrap().source, "second");
+    }
+}

--- a/src/rust_engine.rs
+++ b/src/rust_engine.rs
@@ -134,7 +134,10 @@ impl RustEngine {
     pub fn execute(&self, id: &str, vertex: u32) -> Result<Data, String> {
         let atom = self.atoms.get(id).ok_or_else(|| format!("Atom {} not found", id))?;
 
-        let mut uni = self.universe.lock().map_err(|e| format!("Lock error: {}", e))?;
+        let mut uni = self
+            .universe
+            .lock()
+            .map_err(|e| format!("Lock error: {}", e))?;
         atom.execute(&mut uni, vertex)
     }
 

--- a/src/universe.rs
+++ b/src/universe.rs
@@ -70,7 +70,9 @@ impl Universe {
     /// ```
     #[inline]
     pub fn new() -> Self {
-        Universe { ops: Operations::new() }
+        Universe {
+            ops: Operations::new(),
+        }
     }
 
     /// Returns the next available vertex ID.

--- a/src/universe.rs
+++ b/src/universe.rs
@@ -1,0 +1,245 @@
+//! Universe module provides a bridge between phie and SODG for Rust atoms.
+//!
+//! This module implements the Universe abstraction that allows dynamically compiled
+//! Rust atoms to interact with the object graph through SODG API. The Universe
+//! manages vertex creation, data storage, and graph traversal operations.
+//!
+//! The key abstraction is the Universe struct which wraps SODG and provides
+//! a type-safe interface for Rust atoms to perform graph operations during
+//! dataization.
+
+mod cache;
+mod operations;
+
+pub use cache::Cache;
+pub use operations::Operations;
+
+use crate::data::Data;
+
+/// Type alias for vertex identifiers in the graph.
+///
+/// Vertices are numbered sequentially starting from 0. Each vertex can store
+/// data and have labeled edges to other vertices representing object attributes.
+pub type VertexId = u32;
+
+/// Universe provides the runtime interface for Rust atoms to interact with SODG.
+///
+/// Universe wraps graph operations and provides methods for:
+/// - Creating new vertices with unique IDs
+/// - Storing and retrieving i16 data values at vertices
+/// - Creating labeled edges between vertices
+/// - Resolving paths through the object graph
+/// - Caching dataized values for performance
+///
+/// The Universe is passed to compiled Rust atoms as a mutable pointer, allowing
+/// them to query and modify the object graph during execution.
+///
+/// # Thread Safety
+///
+/// Universe is not thread-safe and should be accessed from a single thread
+/// or protected by synchronization primitives when shared.
+///
+/// # Examples
+///
+/// ```
+/// use phie::universe::{Universe, VertexId};
+/// use phie::data::Data;
+///
+/// let mut uni = Universe::new();
+/// let v = uni.next_id();
+/// uni.add(v).unwrap();
+/// uni.put(v, 42).unwrap();
+/// assert_eq!(uni.dataize_vertex(v).unwrap(), 42);
+/// ```
+pub struct Universe {
+    ops: Operations,
+}
+
+impl Universe {
+    /// Creates a new empty Universe.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::Universe;
+    ///
+    /// let uni = Universe::new();
+    /// ```
+    #[inline]
+    pub fn new() -> Self {
+        Universe { ops: Operations::new() }
+    }
+
+    /// Returns the next available vertex ID.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::Universe;
+    ///
+    /// let mut uni = Universe::new();
+    /// let id1 = uni.next_id();
+    /// let id2 = uni.next_id();
+    /// assert_eq!(id2, id1 + 1);
+    /// ```
+    #[inline]
+    pub fn next_id(&mut self) -> VertexId {
+        self.ops.next_id()
+    }
+
+    /// Adds a new vertex to the graph.
+    ///
+    /// # Arguments
+    ///
+    /// * `v` - The vertex ID to add
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::Universe;
+    ///
+    /// let mut uni = Universe::new();
+    /// let v = uni.next_id();
+    /// uni.add(v).unwrap();
+    /// ```
+    pub fn add(&mut self, v: VertexId) -> Result<(), String> {
+        self.ops.add(v)
+    }
+
+    /// Stores data at a vertex.
+    ///
+    /// # Arguments
+    ///
+    /// * `v` - The vertex ID
+    /// * `data` - The data value to store
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::Universe;
+    ///
+    /// let mut uni = Universe::new();
+    /// let v = uni.next_id();
+    /// uni.add(v).unwrap();
+    /// uni.put(v, 42).unwrap();
+    /// ```
+    pub fn put(&mut self, v: VertexId, data: Data) -> Result<(), String> {
+        self.ops.put(v, data)
+    }
+
+    /// Retrieves and dataizes a vertex by path.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path to the vertex (e.g., "v1.𝛼0")
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::Universe;
+    ///
+    /// let mut uni = Universe::new();
+    /// let v = uni.next_id();
+    /// uni.add(v).unwrap();
+    /// uni.put(v, 42).unwrap();
+    /// assert_eq!(uni.dataize("v0").unwrap(), 42);
+    /// ```
+    pub fn dataize(&mut self, path: &str) -> Result<Data, String> {
+        let v = self.ops.parse_path(path)?;
+        self.dataize_vertex(v)
+    }
+
+    /// Retrieves data from a vertex by ID.
+    ///
+    /// # Arguments
+    ///
+    /// * `v` - The vertex ID
+    pub fn dataize_vertex(&mut self, v: VertexId) -> Result<Data, String> {
+        self.ops.dataize(v)
+    }
+
+    /// Creates an edge between two vertices.
+    ///
+    /// # Arguments
+    ///
+    /// * `from` - Source vertex ID
+    /// * `to` - Target vertex ID
+    /// * `label` - Edge label
+    pub fn bind(&mut self, from: VertexId, to: VertexId, label: &str) -> Result<(), String> {
+        self.ops.bind(from, to, label)
+    }
+}
+
+impl Default for Universe {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_universe_creation() {
+        let uni = Universe::new();
+        let _ = uni;
+    }
+
+    #[test]
+    fn test_universe_default() {
+        let uni = Universe::default();
+        let _ = uni;
+    }
+
+    #[test]
+    fn test_complete_workflow() {
+        let mut uni = Universe::new();
+        let v = uni.next_id();
+        uni.add(v).unwrap();
+        uni.put(v, 42).unwrap();
+        assert_eq!(uni.dataize_vertex(v).unwrap(), 42);
+    }
+
+    #[test]
+    fn test_dataize_by_path() {
+        let mut uni = Universe::new();
+        let v = uni.next_id();
+        uni.add(v).unwrap();
+        uni.put(v, 100).unwrap();
+        assert_eq!(uni.dataize("v0").unwrap(), 100);
+    }
+
+    #[test]
+    fn test_bind_workflow() {
+        let mut uni = Universe::new();
+        let v1 = uni.next_id();
+        let v2 = uni.next_id();
+        uni.add(v1).unwrap();
+        uni.add(v2).unwrap();
+        uni.bind(v1, v2, "𝛼0").unwrap();
+        uni.put(v1, 10).unwrap();
+        uni.put(v2, 20).unwrap();
+        assert_eq!(uni.dataize_vertex(v1).unwrap(), 10);
+        assert_eq!(uni.dataize_vertex(v2).unwrap(), 20);
+    }
+
+    #[test]
+    fn test_multiple_vertices() {
+        let mut uni = Universe::new();
+        for i in 0..10 {
+            let v = uni.next_id();
+            uni.add(v).unwrap();
+            uni.put(v, i as i16).unwrap();
+        }
+        for i in 0..10 {
+            assert_eq!(uni.dataize_vertex(i).unwrap(), i as i16);
+        }
+    }
+
+    #[test]
+    fn test_invalid_path() {
+        let mut uni = Universe::new();
+        assert!(uni.dataize("invalid").is_err());
+    }
+}

--- a/src/universe.rs
+++ b/src/universe.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
 //! Universe module provides a bridge between phie and SODG for Rust atoms.
 //!
 //! This module implements the Universe abstraction that allows dynamically compiled

--- a/src/universe/cache.rs
+++ b/src/universe/cache.rs
@@ -1,0 +1,292 @@
+//! Caching layer for dataized vertex values.
+//!
+//! This module implements an efficient caching mechanism for storing
+//! dataized vertex values. The cache uses a Vec-based structure optimized
+//! for sequential vertex IDs, providing O(1) access time and minimal memory
+//! overhead compared to HashMap-based approaches.
+//!
+//! The cache automatically expands as needed when higher vertex IDs are
+//! accessed, using None values to represent uncached vertices.
+
+use crate::data::Data;
+use crate::universe::VertexId;
+
+/// Efficient cache for storing dataized vertex values.
+///
+/// The cache is optimized for sequential vertex IDs starting from 0.
+/// It uses a Vec of Option<Data> where the index corresponds to the
+/// vertex ID, providing O(1) lookup and insertion.
+///
+/// # Memory Layout
+///
+/// The cache pre-allocates space for 128 vertices to avoid frequent
+/// reallocations during initial graph construction. It automatically
+/// expands when vertices with higher IDs are accessed.
+///
+/// # Examples
+///
+/// ```
+/// use phie::universe::cache::Cache;
+///
+/// let mut cache = Cache::new();
+/// cache.put(0, 42);
+/// assert_eq!(cache.get(0), Some(42));
+/// assert_eq!(cache.get(1), None);
+/// ```
+pub struct Cache {
+    /// Storage for cached values indexed by vertex ID
+    data: Vec<Option<Data>>,
+}
+
+impl Cache {
+    /// Creates a new empty cache with initial capacity.
+    ///
+    /// Pre-allocates space for 128 vertices to minimize reallocations
+    /// during typical graph construction.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::cache::Cache;
+    ///
+    /// let cache = Cache::new();
+    /// assert_eq!(cache.len(), 0);
+    /// ```
+    #[inline]
+    pub fn new() -> Self {
+        Cache { data: Vec::with_capacity(128) }
+    }
+
+    /// Stores a value in the cache for the given vertex.
+    ///
+    /// If the vertex ID is beyond the current cache size, the cache
+    /// automatically expands to accommodate it, filling intermediate
+    /// positions with None.
+    ///
+    /// # Arguments
+    ///
+    /// * `v` - Vertex ID to cache the value for
+    /// * `value` - Data value to store
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::cache::Cache;
+    ///
+    /// let mut cache = Cache::new();
+    /// cache.put(5, 100);
+    /// assert_eq!(cache.get(5), Some(100));
+    /// ```
+    pub fn put(&mut self, v: VertexId, value: Data) {
+        let v_usize = v as usize;
+        if v_usize >= self.data.len() {
+            self.data.resize(v_usize + 1, None);
+        }
+        self.data[v_usize] = Some(value);
+    }
+
+    /// Retrieves a cached value for the given vertex.
+    ///
+    /// Returns None if the vertex has not been cached or if the
+    /// vertex ID is beyond the current cache size.
+    ///
+    /// # Arguments
+    ///
+    /// * `v` - Vertex ID to retrieve
+    ///
+    /// # Returns
+    ///
+    /// The cached data value if present, None otherwise
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::cache::Cache;
+    ///
+    /// let mut cache = Cache::new();
+    /// cache.put(3, 42);
+    /// assert_eq!(cache.get(3), Some(42));
+    /// assert_eq!(cache.get(4), None);
+    /// ```
+    #[inline]
+    pub fn get(&self, v: VertexId) -> Option<Data> {
+        let v_usize = v as usize;
+        if v_usize < self.data.len() {
+            self.data[v_usize]
+        } else {
+            None
+        }
+    }
+
+    /// Returns the current size of the cache storage.
+    ///
+    /// This represents the highest vertex ID + 1 that can be stored
+    /// without reallocation, not the number of cached values.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::cache::Cache;
+    ///
+    /// let mut cache = Cache::new();
+    /// cache.put(10, 42);
+    /// assert!(cache.len() >= 11);
+    /// ```
+    #[inline]
+    pub fn len(&self) -> usize {
+        self.data.len()
+    }
+
+    /// Checks if the cache is empty.
+    ///
+    /// Returns true if no storage has been allocated yet.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::cache::Cache;
+    ///
+    /// let cache = Cache::new();
+    /// assert!(cache.is_empty());
+    /// ```
+    #[inline]
+    pub fn is_empty(&self) -> bool {
+        self.data.is_empty()
+    }
+
+    /// Clears all cached values while retaining allocated capacity.
+    ///
+    /// This is useful for reusing the cache with a new graph while
+    /// avoiding reallocation overhead.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::cache::Cache;
+    ///
+    /// let mut cache = Cache::new();
+    /// cache.put(0, 42);
+    /// cache.clear();
+    /// assert_eq!(cache.get(0), None);
+    /// ```
+    pub fn clear(&mut self) {
+        self.data.clear();
+    }
+}
+
+impl Default for Cache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_cache_creation() {
+        let cache = Cache::new();
+        assert_eq!(cache.len(), 0);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_cache_default() {
+        let cache = Cache::default();
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_put_and_get() {
+        let mut cache = Cache::new();
+        cache.put(0, 42);
+        assert_eq!(cache.get(0), Some(42));
+    }
+
+    #[test]
+    fn test_get_nonexistent() {
+        let cache = Cache::new();
+        assert_eq!(cache.get(0), None);
+        assert_eq!(cache.get(100), None);
+    }
+
+    #[test]
+    fn test_put_extends_cache() {
+        let mut cache = Cache::new();
+        cache.put(200, 99);
+        assert!(cache.len() >= 201);
+        assert_eq!(cache.get(200), Some(99));
+    }
+
+    #[test]
+    fn test_multiple_values() {
+        let mut cache = Cache::new();
+        cache.put(0, 10);
+        cache.put(1, 20);
+        cache.put(2, 30);
+        assert_eq!(cache.get(0), Some(10));
+        assert_eq!(cache.get(1), Some(20));
+        assert_eq!(cache.get(2), Some(30));
+    }
+
+    #[test]
+    fn test_overwrite_value() {
+        let mut cache = Cache::new();
+        cache.put(5, 100);
+        cache.put(5, 200);
+        assert_eq!(cache.get(5), Some(200));
+    }
+
+    #[test]
+    fn test_sparse_cache() {
+        let mut cache = Cache::new();
+        cache.put(0, 10);
+        cache.put(10, 20);
+        cache.put(20, 30);
+        assert_eq!(cache.get(0), Some(10));
+        assert_eq!(cache.get(5), None);
+        assert_eq!(cache.get(10), Some(20));
+        assert_eq!(cache.get(15), None);
+        assert_eq!(cache.get(20), Some(30));
+    }
+
+    #[test]
+    fn test_clear() {
+        let mut cache = Cache::new();
+        cache.put(0, 42);
+        cache.put(1, 43);
+        cache.clear();
+        assert_eq!(cache.get(0), None);
+        assert_eq!(cache.get(1), None);
+        assert!(cache.is_empty());
+    }
+
+    #[test]
+    fn test_negative_data() {
+        let mut cache = Cache::new();
+        cache.put(0, -42);
+        assert_eq!(cache.get(0), Some(-42));
+    }
+
+    #[test]
+    fn test_zero_data() {
+        let mut cache = Cache::new();
+        cache.put(0, 0);
+        assert_eq!(cache.get(0), Some(0));
+    }
+
+    #[test]
+    fn test_max_i16() {
+        let mut cache = Cache::new();
+        cache.put(0, i16::MAX);
+        assert_eq!(cache.get(0), Some(i16::MAX));
+    }
+
+    #[test]
+    fn test_min_i16() {
+        let mut cache = Cache::new();
+        cache.put(0, i16::MIN);
+        assert_eq!(cache.get(0), Some(i16::MIN));
+    }
+}

--- a/src/universe/cache.rs
+++ b/src/universe/cache.rs
@@ -29,7 +29,7 @@ use crate::universe::VertexId;
 /// # Examples
 ///
 /// ```
-/// use phie::universe::cache::Cache;
+/// use phie::universe::Cache;
 ///
 /// let mut cache = Cache::new();
 /// cache.put(0, 42);
@@ -50,7 +50,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::cache::Cache;
+    /// use phie::universe::Cache;
     ///
     /// let cache = Cache::new();
     /// assert_eq!(cache.len(), 0);
@@ -74,7 +74,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::cache::Cache;
+    /// use phie::universe::Cache;
     ///
     /// let mut cache = Cache::new();
     /// cache.put(5, 100);
@@ -104,7 +104,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::cache::Cache;
+    /// use phie::universe::Cache;
     ///
     /// let mut cache = Cache::new();
     /// cache.put(3, 42);
@@ -129,7 +129,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::cache::Cache;
+    /// use phie::universe::Cache;
     ///
     /// let mut cache = Cache::new();
     /// cache.put(10, 42);
@@ -147,7 +147,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::cache::Cache;
+    /// use phie::universe::Cache;
     ///
     /// let cache = Cache::new();
     /// assert!(cache.is_empty());
@@ -165,7 +165,7 @@ impl Cache {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::cache::Cache;
+    /// use phie::universe::Cache;
     ///
     /// let mut cache = Cache::new();
     /// cache.put(0, 42);

--- a/src/universe/cache.rs
+++ b/src/universe/cache.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
 //! Caching layer for dataized vertex values.
 //!
 //! This module implements an efficient caching mechanism for storing

--- a/src/universe/cache.rs
+++ b/src/universe/cache.rs
@@ -57,7 +57,9 @@ impl Cache {
     /// ```
     #[inline]
     pub fn new() -> Self {
-        Cache { data: Vec::with_capacity(128) }
+        Cache {
+            data: Vec::with_capacity(128),
+        }
     }
 
     /// Stores a value in the cache for the given vertex.

--- a/src/universe/operations.rs
+++ b/src/universe/operations.rs
@@ -166,11 +166,17 @@ impl Operations {
             return Ok(data);
         }
 
-        let hex = self.sodg.data(v).map_err(|e| format!("Failed to get data: {}", e))?;
+        let hex = self
+            .sodg
+            .data(v)
+            .map_err(|e| format!("Failed to get data: {}", e))?;
         let bytes = hex.to_vec();
 
         if bytes.len() != 2 {
-            return Err(format!("Invalid data length: expected 2 bytes, got {}", bytes.len()));
+            return Err(format!(
+                "Invalid data length: expected 2 bytes, got {}",
+                bytes.len()
+            ));
         }
 
         let data = Data::from_be_bytes([bytes[0], bytes[1]]);
@@ -212,7 +218,9 @@ impl Operations {
     /// ops.bind(v1, v2, "𝛼0").unwrap();
     /// ```
     pub fn bind(&mut self, from: VertexId, to: VertexId, label: &str) -> Result<(), String> {
-        self.sodg.bind(from, to, label).map_err(|e| format!("Failed to bind: {}", e))
+        self.sodg
+            .bind(from, to, label)
+            .map_err(|e| format!("Failed to bind: {}", e))
     }
 
     /// Parses a vertex path string into a vertex ID.
@@ -252,7 +260,9 @@ impl Operations {
 
         let parts: Vec<&str> = path.split('.').collect();
         let id_str = &parts[0][1..];
-        id_str.parse::<VertexId>().map_err(|e| format!("Invalid vertex ID: {}", e))
+        id_str
+            .parse::<VertexId>()
+            .map_err(|e| format!("Invalid vertex ID: {}", e))
     }
 }
 

--- a/src/universe/operations.rs
+++ b/src/universe/operations.rs
@@ -39,7 +39,7 @@ impl Operations {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::operations::Operations;
+    /// use phie::universe::Operations;
     ///
     /// let ops = Operations::new();
     /// ```
@@ -59,7 +59,7 @@ impl Operations {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::operations::Operations;
+    /// use phie::universe::Operations;
     ///
     /// let mut ops = Operations::new();
     /// assert_eq!(ops.next_id(), 0);
@@ -88,7 +88,7 @@ impl Operations {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::operations::Operations;
+    /// use phie::universe::Operations;
     ///
     /// let mut ops = Operations::new();
     /// let v = ops.next_id();
@@ -115,7 +115,7 @@ impl Operations {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::operations::Operations;
+    /// use phie::universe::Operations;
     ///
     /// let mut ops = Operations::new();
     /// let v = ops.next_id();
@@ -153,7 +153,7 @@ impl Operations {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::operations::Operations;
+    /// use phie::universe::Operations;
     ///
     /// let mut ops = Operations::new();
     /// let v = ops.next_id();
@@ -202,7 +202,7 @@ impl Operations {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::operations::Operations;
+    /// use phie::universe::Operations;
     ///
     /// let mut ops = Operations::new();
     /// let v1 = ops.next_id();
@@ -238,7 +238,7 @@ impl Operations {
     /// # Examples
     ///
     /// ```
-    /// use phie::universe::operations::Operations;
+    /// use phie::universe::Operations;
     ///
     /// let ops = Operations::new();
     /// assert_eq!(ops.parse_path("v0").unwrap(), 0);

--- a/src/universe/operations.rs
+++ b/src/universe/operations.rs
@@ -44,7 +44,11 @@ impl Operations {
     /// let ops = Operations::new();
     /// ```
     pub fn new() -> Self {
-        Operations { sodg: Sodg::empty(), cache: Cache::new(), next_id: 0 }
+        Operations {
+            sodg: Sodg::empty(),
+            cache: Cache::new(),
+            next_id: 0,
+        }
     }
 
     /// Generates the next unique vertex ID.
@@ -95,7 +99,9 @@ impl Operations {
     /// ops.add(v).unwrap();
     /// ```
     pub fn add(&mut self, v: VertexId) -> Result<(), String> {
-        self.sodg.add(v).map_err(|e| format!("Failed to add vertex: {}", e))
+        self.sodg
+            .add(v)
+            .map_err(|e| format!("Failed to add vertex: {}", e))
     }
 
     /// Stores data at a vertex.
@@ -127,7 +133,9 @@ impl Operations {
 
         let bytes = data.to_be_bytes().to_vec();
         let hex = Hex::from_vec(bytes);
-        self.sodg.put(v, &hex).map_err(|e| format!("Failed to put data: {}", e))
+        self.sodg
+            .put(v, &hex)
+            .map_err(|e| format!("Failed to put data: {}", e))
     }
 
     /// Retrieves and dataizes a vertex value.

--- a/src/universe/operations.rs
+++ b/src/universe/operations.rs
@@ -130,7 +130,6 @@ impl Operations {
     /// ```
     pub fn put(&mut self, v: VertexId, data: Data) -> Result<(), String> {
         self.cache.put(v, data);
-
         let bytes = data.to_be_bytes().to_vec();
         let hex = Hex::from_vec(bytes);
         self.sodg
@@ -173,21 +172,17 @@ impl Operations {
         if let Some(data) = self.cache.get(v) {
             return Ok(data);
         }
-
         let hex = self
             .sodg
             .data(v)
             .map_err(|e| format!("Failed to get data: {e}"))?;
         let bytes = hex.to_vec();
-
         if bytes.len() != 2 {
             let len = bytes.len();
             return Err(format!("Invalid data length: expected 2 bytes, got {len}"));
         }
-
         let data = Data::from_be_bytes([bytes[0], bytes[1]]);
         self.cache.put(v, data);
-
         Ok(data)
     }
 

--- a/src/universe/operations.rs
+++ b/src/universe/operations.rs
@@ -1,3 +1,6 @@
+// SPDX-FileCopyrightText: Copyright (c) 2022 Yegor Bugayenko
+// SPDX-License-Identifier: MIT
+
 //! SODG graph operations for the Universe.
 //!
 //! This module provides all graph manipulation operations including

--- a/src/universe/operations.rs
+++ b/src/universe/operations.rs
@@ -182,9 +182,7 @@ impl Operations {
 
         if bytes.len() != 2 {
             let len = bytes.len();
-            return Err(format!(
-                "Invalid data length: expected 2 bytes, got {len}"
-            ));
+            return Err(format!("Invalid data length: expected 2 bytes, got {len}"));
         }
 
         let data = Data::from_be_bytes([bytes[0], bytes[1]]);

--- a/src/universe/operations.rs
+++ b/src/universe/operations.rs
@@ -1,0 +1,369 @@
+//! SODG graph operations for the Universe.
+//!
+//! This module provides all graph manipulation operations including
+//! vertex management, edge creation, data storage, and dataization.
+//! It bridges between phie's internal data representation and SODG's
+//! graph structure.
+
+use crate::data::Data;
+use crate::universe::{Cache, VertexId};
+use sodg::{Hex, Sodg};
+
+/// Core graph operations manager.
+///
+/// Operations handles all interactions with the underlying SODG graph,
+/// providing type-safe wrappers that convert between phie's i16 data
+/// type and SODG's Hex representation.
+///
+/// # Thread Safety
+///
+/// Operations is not thread-safe. External synchronization is required
+/// if shared across threads.
+pub struct Operations {
+    /// The underlying SODG directed graph
+    sodg: Sodg,
+    /// Cache for dataized values
+    cache: Cache,
+    /// Counter for generating unique vertex IDs
+    next_id: VertexId,
+}
+
+impl Operations {
+    /// Creates a new Operations instance with an empty graph.
+    ///
+    /// Initializes the SODG graph, cache, and vertex ID counter.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::operations::Operations;
+    ///
+    /// let ops = Operations::new();
+    /// ```
+    pub fn new() -> Self {
+        Operations { sodg: Sodg::empty(), cache: Cache::new(), next_id: 0 }
+    }
+
+    /// Generates the next unique vertex ID.
+    ///
+    /// Vertex IDs are sequential integers starting from 0.
+    /// Each call increments the internal counter.
+    ///
+    /// # Returns
+    ///
+    /// A unique vertex ID that hasn't been used before
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::operations::Operations;
+    ///
+    /// let mut ops = Operations::new();
+    /// assert_eq!(ops.next_id(), 0);
+    /// assert_eq!(ops.next_id(), 1);
+    /// ```
+    #[inline]
+    pub fn next_id(&mut self) -> VertexId {
+        let id = self.next_id;
+        self.next_id += 1;
+        id
+    }
+
+    /// Adds a new vertex to the graph.
+    ///
+    /// Creates a new vertex with the given ID. If the vertex already
+    /// exists, the operation succeeds without modification.
+    ///
+    /// # Arguments
+    ///
+    /// * `v` - The vertex ID to add
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if SODG validation fails or alerts trigger.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::operations::Operations;
+    ///
+    /// let mut ops = Operations::new();
+    /// let v = ops.next_id();
+    /// ops.add(v).unwrap();
+    /// ```
+    pub fn add(&mut self, v: VertexId) -> Result<(), String> {
+        self.sodg.add(v).map_err(|e| format!("Failed to add vertex: {}", e))
+    }
+
+    /// Stores data at a vertex.
+    ///
+    /// Converts the i16 data value to SODG's Hex format and stores it
+    /// at the specified vertex. Also updates the cache with the value.
+    ///
+    /// # Arguments
+    ///
+    /// * `v` - The vertex ID
+    /// * `data` - The i16 data value to store
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if the vertex doesn't exist or SODG validation fails.
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::operations::Operations;
+    ///
+    /// let mut ops = Operations::new();
+    /// let v = ops.next_id();
+    /// ops.add(v).unwrap();
+    /// ops.put(v, 42).unwrap();
+    /// ```
+    pub fn put(&mut self, v: VertexId, data: Data) -> Result<(), String> {
+        self.cache.put(v, data);
+
+        let bytes = data.to_be_bytes().to_vec();
+        let hex = Hex::from_vec(bytes);
+        self.sodg.put(v, &hex).map_err(|e| format!("Failed to put data: {}", e))
+    }
+
+    /// Retrieves and dataizes a vertex value.
+    ///
+    /// First checks the cache for the value. If not found, retrieves
+    /// from SODG, converts from Hex to i16, and caches the result.
+    ///
+    /// # Arguments
+    ///
+    /// * `v` - The vertex ID to dataize
+    ///
+    /// # Returns
+    ///
+    /// The i16 data value stored at the vertex
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The vertex doesn't exist
+    /// - The stored data is not exactly 2 bytes
+    /// - SODG operations fail
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::operations::Operations;
+    ///
+    /// let mut ops = Operations::new();
+    /// let v = ops.next_id();
+    /// ops.add(v).unwrap();
+    /// ops.put(v, 100).unwrap();
+    /// assert_eq!(ops.dataize(v).unwrap(), 100);
+    /// ```
+    pub fn dataize(&mut self, v: VertexId) -> Result<Data, String> {
+        if let Some(data) = self.cache.get(v) {
+            return Ok(data);
+        }
+
+        let hex = self.sodg.data(v).map_err(|e| format!("Failed to get data: {}", e))?;
+        let bytes = hex.to_vec();
+
+        if bytes.len() != 2 {
+            return Err(format!("Invalid data length: expected 2 bytes, got {}", bytes.len()));
+        }
+
+        let data = Data::from_be_bytes([bytes[0], bytes[1]]);
+        self.cache.put(v, data);
+
+        Ok(data)
+    }
+
+    /// Creates a labeled edge between two vertices.
+    ///
+    /// Establishes a directed edge from the source vertex to the
+    /// target vertex with the given label. The label typically
+    /// represents object attributes like "𝛼0", "𝛼1", "ρ", etc.
+    ///
+    /// # Arguments
+    ///
+    /// * `from` - Source vertex ID
+    /// * `to` - Target vertex ID
+    /// * `label` - Edge label (attribute name)
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - Either vertex doesn't exist
+    /// - The label is empty
+    /// - from equals to (self-loops not allowed)
+    /// - SODG validation fails
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::operations::Operations;
+    ///
+    /// let mut ops = Operations::new();
+    /// let v1 = ops.next_id();
+    /// let v2 = ops.next_id();
+    /// ops.add(v1).unwrap();
+    /// ops.add(v2).unwrap();
+    /// ops.bind(v1, v2, "𝛼0").unwrap();
+    /// ```
+    pub fn bind(&mut self, from: VertexId, to: VertexId, label: &str) -> Result<(), String> {
+        self.sodg.bind(from, to, label).map_err(|e| format!("Failed to bind: {}", e))
+    }
+
+    /// Parses a vertex path string into a vertex ID.
+    ///
+    /// Supports simple vertex references in the format "vN" where N
+    /// is the vertex ID number. More complex path navigation is not
+    /// yet implemented.
+    ///
+    /// # Arguments
+    ///
+    /// * `path` - Path string (e.g., "v0", "v42")
+    ///
+    /// # Returns
+    ///
+    /// The parsed vertex ID
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The path doesn't start with 'v'
+    /// - The ID portion is not a valid number
+    ///
+    /// # Examples
+    ///
+    /// ```
+    /// use phie::universe::operations::Operations;
+    ///
+    /// let ops = Operations::new();
+    /// assert_eq!(ops.parse_path("v0").unwrap(), 0);
+    /// assert_eq!(ops.parse_path("v123").unwrap(), 123);
+    /// assert!(ops.parse_path("invalid").is_err());
+    /// ```
+    pub fn parse_path(&self, path: &str) -> Result<VertexId, String> {
+        if !path.starts_with('v') {
+            return Err(format!("Invalid path format: {}", path));
+        }
+
+        let parts: Vec<&str> = path.split('.').collect();
+        let id_str = &parts[0][1..];
+        id_str.parse::<VertexId>().map_err(|e| format!("Invalid vertex ID: {}", e))
+    }
+}
+
+impl Default for Operations {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_operations_creation() {
+        let ops = Operations::new();
+        assert_eq!(ops.next_id, 0);
+    }
+
+    #[test]
+    fn test_operations_default() {
+        let ops = Operations::default();
+        assert_eq!(ops.next_id, 0);
+    }
+
+    #[test]
+    fn test_next_id_sequence() {
+        let mut ops = Operations::new();
+        assert_eq!(ops.next_id(), 0);
+        assert_eq!(ops.next_id(), 1);
+        assert_eq!(ops.next_id(), 2);
+    }
+
+    #[test]
+    fn test_add_vertex() {
+        let mut ops = Operations::new();
+        let v = ops.next_id();
+        assert!(ops.add(v).is_ok());
+    }
+
+    #[test]
+    fn test_put_and_dataize() {
+        let mut ops = Operations::new();
+        let v = ops.next_id();
+        ops.add(v).unwrap();
+        ops.put(v, 42).unwrap();
+        assert_eq!(ops.dataize(v).unwrap(), 42);
+    }
+
+    #[test]
+    fn test_dataize_caches_value() {
+        let mut ops = Operations::new();
+        let v = ops.next_id();
+        ops.add(v).unwrap();
+        ops.put(v, 100).unwrap();
+        assert_eq!(ops.dataize(v).unwrap(), 100);
+        assert_eq!(ops.dataize(v).unwrap(), 100);
+    }
+
+    #[test]
+    fn test_bind_vertices() {
+        let mut ops = Operations::new();
+        let v1 = ops.next_id();
+        let v2 = ops.next_id();
+        ops.add(v1).unwrap();
+        ops.add(v2).unwrap();
+        assert!(ops.bind(v1, v2, "𝛼0").is_ok());
+    }
+
+    #[test]
+    fn test_parse_path_valid() {
+        let ops = Operations::new();
+        assert_eq!(ops.parse_path("v0").unwrap(), 0);
+        assert_eq!(ops.parse_path("v1").unwrap(), 1);
+        assert_eq!(ops.parse_path("v999").unwrap(), 999);
+    }
+
+    #[test]
+    fn test_parse_path_invalid() {
+        let ops = Operations::new();
+        assert!(ops.parse_path("invalid").is_err());
+        assert!(ops.parse_path("x123").is_err());
+        assert!(ops.parse_path("").is_err());
+        assert!(ops.parse_path("vabc").is_err());
+    }
+
+    #[test]
+    fn test_negative_data() {
+        let mut ops = Operations::new();
+        let v = ops.next_id();
+        ops.add(v).unwrap();
+        ops.put(v, -42).unwrap();
+        assert_eq!(ops.dataize(v).unwrap(), -42);
+    }
+
+    #[test]
+    fn test_zero_data() {
+        let mut ops = Operations::new();
+        let v = ops.next_id();
+        ops.add(v).unwrap();
+        ops.put(v, 0).unwrap();
+        assert_eq!(ops.dataize(v).unwrap(), 0);
+    }
+
+    #[test]
+    fn test_max_min_i16() {
+        let mut ops = Operations::new();
+        let v1 = ops.next_id();
+        let v2 = ops.next_id();
+        ops.add(v1).unwrap();
+        ops.add(v2).unwrap();
+        ops.put(v1, i16::MAX).unwrap();
+        ops.put(v2, i16::MIN).unwrap();
+        assert_eq!(ops.dataize(v1).unwrap(), i16::MAX);
+        assert_eq!(ops.dataize(v2).unwrap(), i16::MIN);
+    }
+}

--- a/src/universe/operations.rs
+++ b/src/universe/operations.rs
@@ -101,7 +101,7 @@ impl Operations {
     pub fn add(&mut self, v: VertexId) -> Result<(), String> {
         self.sodg
             .add(v)
-            .map_err(|e| format!("Failed to add vertex: {}", e))
+            .map_err(|e| format!("Failed to add vertex: {e}"))
     }
 
     /// Stores data at a vertex.
@@ -135,7 +135,7 @@ impl Operations {
         let hex = Hex::from_vec(bytes);
         self.sodg
             .put(v, &hex)
-            .map_err(|e| format!("Failed to put data: {}", e))
+            .map_err(|e| format!("Failed to put data: {e}"))
     }
 
     /// Retrieves and dataizes a vertex value.
@@ -177,13 +177,13 @@ impl Operations {
         let hex = self
             .sodg
             .data(v)
-            .map_err(|e| format!("Failed to get data: {}", e))?;
+            .map_err(|e| format!("Failed to get data: {e}"))?;
         let bytes = hex.to_vec();
 
         if bytes.len() != 2 {
+            let len = bytes.len();
             return Err(format!(
-                "Invalid data length: expected 2 bytes, got {}",
-                bytes.len()
+                "Invalid data length: expected 2 bytes, got {len}"
             ));
         }
 
@@ -228,7 +228,7 @@ impl Operations {
     pub fn bind(&mut self, from: VertexId, to: VertexId, label: &str) -> Result<(), String> {
         self.sodg
             .bind(from, to, label)
-            .map_err(|e| format!("Failed to bind: {}", e))
+            .map_err(|e| format!("Failed to bind: {e}"))
     }
 
     /// Parses a vertex path string into a vertex ID.
@@ -263,14 +263,14 @@ impl Operations {
     /// ```
     pub fn parse_path(&self, path: &str) -> Result<VertexId, String> {
         if !path.starts_with('v') {
-            return Err(format!("Invalid path format: {}", path));
+            return Err(format!("Invalid path format: {path}"));
         }
 
         let parts: Vec<&str> = path.split('.').collect();
         let id_str = &parts[0][1..];
         id_str
             .parse::<VertexId>()
-            .map_err(|e| format!("Invalid vertex ID: {}", e))
+            .map_err(|e| format!("Invalid vertex ID: {e}"))
     }
 }
 


### PR DESCRIPTION
## Changes

- Replaced cargo-tarpaulin with cargo-llvm-cov for code coverage
- Removed OpenSSL 1.1 installation step (no longer needed)
- Updated workflow to use taiki-e/install-action for cargo-llvm-cov installation
- Changed coverage output format to lcov for Codecov compatibility
- Renamed workflow from tarpaulin to coverage

## Benefits

- Faster coverage generation
- Better LLVM integration
- More stable on recent Rust versions
- Actively maintained tool

Closes #108