### PR TITLE
Make cli_test mktemp paths unique to fix /tmp race (#104)

### DIFF
--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -4,10 +4,15 @@
 use phie::cli;
 use std::fs;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
+
+static MKTEMP_COUNTER: AtomicU64 = AtomicU64::new(0);
 
 fn mktemp(filename: &str) -> (PathBuf, String) {
+    let serial = MKTEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let pid = std::process::id();
     let mut file = std::env::temp_dir();
-    file.push(filename);
+    file.push(format!("phie-{pid}-{serial}-{filename}"));
     let path = file.clone().into_os_string().into_string().unwrap();
     (file, path)
 }

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -215,15 +215,23 @@ fn parallel_mktemp_users_do_not_clash() {
             let (file, path) = mktemp("phie_test_parallel.phie");
             collected.lock().unwrap().push(path.clone());
             if let Err(err) = fs::write(&file, "ν0(𝜋) ↦ ⟦ Δ ↦ 0x002A ⟧") {
-                errors.lock().unwrap().push(format!("write {}: {}", path, err));
+                errors
+                    .lock()
+                    .unwrap()
+                    .push(format!("write {}: {}", path, err));
                 return;
             }
-            let result = cli::run(&vec!["phie".to_string(), path.clone()]);
+            let result = cli::run(&["phie".to_string(), path.clone()]);
             if let Err(err) = fs::remove_file(&file) {
-                errors.lock().unwrap().push(format!("remove {}: {}", path, err));
+                errors
+                    .lock()
+                    .unwrap()
+                    .push(format!("remove {}: {}", path, err));
             }
             if !matches!(result.as_deref(), Ok("42")) {
-                errors.lock().unwrap()
+                errors
+                    .lock()
+                    .unwrap()
                     .push(format!("run {} returned {:?}", path, result));
             }
         }));
@@ -232,7 +240,11 @@ fn parallel_mktemp_users_do_not_clash() {
         handle.join().unwrap();
     }
     let errors = errors.lock().unwrap();
-    assert!(errors.is_empty(), "parallel mktemp users clashed: {:?}", *errors);
+    assert!(
+        errors.is_empty(),
+        "parallel mktemp users clashed: {:?}",
+        *errors
+    );
     let collected = collected.lock().unwrap();
     let unique: std::collections::HashSet<&String> = collected.iter().collect();
     assert_eq!(

--- a/tests/cli_test.rs
+++ b/tests/cli_test.rs
@@ -181,3 +181,59 @@ fn preserves_absolute_path() {
     assert!(result.is_ok());
     assert_eq!(result.unwrap(), "/absolute/path/test.phie");
 }
+
+#[test]
+fn mktemp_returns_unique_paths_per_call() {
+    use std::collections::HashSet;
+    let mut paths: HashSet<String> = HashSet::new();
+    for _ in 0..16 {
+        let (_, path) = mktemp("phie_test_unique.phie");
+        assert!(
+            paths.insert(path.clone()),
+            "mktemp returned a duplicate path on repeated calls: {}",
+            path
+        );
+    }
+}
+
+#[test]
+fn parallel_mktemp_users_do_not_clash() {
+    use std::sync::{Arc, Mutex};
+    use std::thread;
+    let collected: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let errors: Arc<Mutex<Vec<String>>> = Arc::new(Mutex::new(Vec::new()));
+    let mut handles = Vec::new();
+    for _ in 0..16 {
+        let collected = collected.clone();
+        let errors = errors.clone();
+        handles.push(thread::spawn(move || {
+            let (file, path) = mktemp("phie_test_parallel.phie");
+            collected.lock().unwrap().push(path.clone());
+            if let Err(err) = fs::write(&file, "ν0(𝜋) ↦ ⟦ Δ ↦ 0x002A ⟧") {
+                errors.lock().unwrap().push(format!("write {}: {}", path, err));
+                return;
+            }
+            let result = cli::run(&vec!["phie".to_string(), path.clone()]);
+            if let Err(err) = fs::remove_file(&file) {
+                errors.lock().unwrap().push(format!("remove {}: {}", path, err));
+            }
+            if !matches!(result.as_deref(), Ok("42")) {
+                errors.lock().unwrap()
+                    .push(format!("run {} returned {:?}", path, result));
+            }
+        }));
+    }
+    for handle in handles {
+        handle.join().unwrap();
+    }
+    let errors = errors.lock().unwrap();
+    assert!(errors.is_empty(), "parallel mktemp users clashed: {:?}", *errors);
+    let collected = collected.lock().unwrap();
+    let unique: std::collections::HashSet<&String> = collected.iter().collect();
+    assert_eq!(
+        collected.len(),
+        unique.len(),
+        "mktemp returned duplicate paths under parallel use: {:?}",
+        *collected
+    );
+}


### PR DESCRIPTION
@yegor256 — this fixes #104.

## Why the issue is real

`tests/cli_test.rs::mktemp(filename)` builds every path as `std::env::temp_dir().join(filename)`, with `filename` hard-coded per test (e.g. `phie_test_addition.phie`, `phie_test_zero.phie`, …). Two callers asking for the same name get the *same* absolute path. So whenever two `cargo test` invocations of this binary overlap (or two threads in the same process happen to use the same name), they share files in `/tmp` and stomp on each other between `fs::write`, `cli::run`, and `fs::remove_file`. The original report (`4 passed; 10 failed`) lines up exactly with this: the parser sees an empty file (`Can't parse emu line: ''`) when another writer has just truncated it, or `fs::remove_file` returns `ENOENT` because another test already deleted it.

Reproduced locally by launching the prebuilt `cli_test` binary 8 times in parallel — every concurrent invocation produced 1–5 failures across `runs_addition_program`, `executes_zero_value`, `handles_whitespace_in_file`, `handles_phi_reference`, `executes_hundred_value`, etc. A single sequential run of `cargo test` only fails the unrelated `fails_with_unreadable_file` (root bypasses `0o000`).

## What changed

1. **Test (commit `6170d84`)** — `tests/cli_test.rs` gains two regression tests that fail on `master` and pass on this branch:
   - `mktemp_returns_unique_paths_per_call` — pulls 16 paths from `mktemp` with the same logical name and asserts they are all distinct. On `master` it trips the very first duplicate (`/tmp/phie_test_unique.phie`).
   - `parallel_mktemp_users_do_not_clash` — spawns 16 threads, each calling `mktemp`, writing a small valid program, running `cli::run`, and removing the file. On `master` this surfaces the exact symptoms the issue reports (parser sees `''`, `fs::remove_file` returns `ENOENT`).

2. **Fix (commit `3c883c3`)** — `mktemp` now prefixes the requested name with the process id and a per-process atomic counter, so every call returns a unique path:

   ```rust
   static MKTEMP_COUNTER: AtomicU64 = AtomicU64::new(0);

   fn mktemp(filename: &str) -> (PathBuf, String) {
       let serial = MKTEMP_COUNTER.fetch_add(1, Ordering::Relaxed);
       let pid = std::process::id();
       let mut file = std::env::temp_dir();
       file.push(format!("phie-{pid}-{serial}-{filename}"));
       ...
   }
   ```

   Different test processes get disjoint paths via PID; concurrent calls within the same process get disjoint paths via the atomic. No new dependencies.

3. **Tooling (commit `6025413`)** — `cargo fmt` and `cargo clippy` cleanups for the new tests (replacing `vec![…]` with a slice literal, breaking long `lock().unwrap().push(…)` chains).

## Verification

- `cargo test --test cli_test` — 16 passed, 1 failed (`fails_with_unreadable_file`, fails only because the local sandbox is root and bypasses `0o000`; CI runs as a non-root user and passes it).
- 8× parallel `cli_test` (`--skip fails_with_unreadable_file`) — all green; the same loop on `master` fails on every run.
- All 10 CI checks on this PR (build, check, actionlint, markdown-lint, yamllint, pdd, copyrights, reuse, xcop, typos) are green.